### PR TITLE
Add cache-busting versioning for modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,7 @@ This project displays a 3D visualization of a cycling route using Three.js. All
 third‑party libraries are now loaded from public CDNs. The **togeojson** library
 is fetched from jsDelivr, so no local copy is required.
 
-Open `index.html` in a modern browser to run the demo.
+Open `index.html` in a modern browser to run the demo. If your browser keeps
+serving old JavaScript files, each module import in `index.html` now includes a
+query string version (e.g. `gpxLoader.js?v=20240401`). Bump this version value
+whenever you deploy a new build to force browsers to fetch the latest assets.

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<meta http-equiv="Cache-Control" content="no-store">
 <title>La bonne échappée</title>
 <style>
 body { margin:0; overflow:hidden; }
@@ -12,8 +13,8 @@ canvas { width:100vw; height:100vh; display:block; }
 <script type="module">
 import * as THREE from 'https://unpkg.com/three@0.163.0/build/three.module.js';
 import { OrbitControls } from 'https://unpkg.com/three@0.163.0/examples/jsm/controls/OrbitControls.js';
-import { curve3D } from './js/gpxLoader.js';
-import { CyclistSim } from './js/physics.js';
+import { curve3D } from './js/gpxLoader.js?v=20240401';
+import { CyclistSim } from './js/physics.js?v=20240401';
 
 const scene = new THREE.Scene();
 const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 10000);


### PR DESCRIPTION
## Summary
- prevent caching of JS modules by appending version query strings
- document the new versioning in README
- ensure browsers don't cache the HTML via meta tag

## Testing
- `npx -y eslint@8 js/*.js`
- `echo "No tests"`

------
https://chatgpt.com/codex/tasks/task_b_687112628ebc8329961b806daa7ed4e5