### PR TITLE
Smooth GPX turns and sync cyclist

### DIFF
--- a/js/gpxLoader.js
+++ b/js/gpxLoader.js
@@ -5,6 +5,29 @@ import { gpx } from './togeojson.esm.js';
 const R = 6371000;
 const RAD = Math.PI / 180;
 
+function smoothPoints(points, iterations = 1) {
+  let result = points;
+  for (let k = 0; k < iterations; k++) {
+    const smoothed = [result[0]];
+    for (let i = 0; i < result.length - 1; i++) {
+      const p0 = result[i];
+      const p1 = result[i + 1];
+      const q = p0
+        .clone()
+        .multiplyScalar(0.75)
+        .add(p1.clone().multiplyScalar(0.25));
+      const r = p0
+        .clone()
+        .multiplyScalar(0.25)
+        .add(p1.clone().multiplyScalar(0.75));
+      smoothed.push(q, r);
+    }
+    smoothed.push(result[result.length - 1]);
+    result = smoothed;
+  }
+  return result;
+}
+
 export async function curve3D(url) {
   const res = await fetch(url);
   const text = await res.text();
@@ -21,5 +44,7 @@ export async function curve3D(url) {
     return new THREE.Vector3(x, y, z);
   });
 
-  return new THREE.CatmullRomCurve3(points);
+  const smooth = smoothPoints(points, 1);
+
+  return new THREE.CatmullRomCurve3(smooth);
 }

--- a/js/physics.js
+++ b/js/physics.js
@@ -8,7 +8,7 @@ export class CyclistSim {
   }
 
   update(dt, mesh) {
-    const tangent = this.curve.getTangent(this.u);
+    const tangent = this.curve.getTangentAt(this.u);
     const horiz = Math.hypot(tangent.x, tangent.z);
     const slope = horiz > 0 ? tangent.y / horiz : 0;
     const accel = -9.8 * slope;
@@ -16,8 +16,8 @@ export class CyclistSim {
     const distance = this.speed * dt;
     this.u += distance / this.length;
     this.u = Math.min(Math.max(this.u, 0), 1);
-    const pos = this.curve.getPoint(this.u);
-    const lookAtPoint = this.curve.getPoint(Math.min(this.u + 0.001, 1));
+    const pos = this.curve.getPointAt(this.u);
+    const lookAtPoint = this.curve.getPointAt(Math.min(this.u + 0.001, 1));
     mesh.position.copy(pos);
     mesh.lookAt(lookAtPoint);
   }


### PR DESCRIPTION
## Summary
- smooth GPX route points before creating the curve
- drive cyclist simulation using arc length instead of raw parameter

## Testing
- `npx -y eslint@8 js/*.js`
- `echo "No tests"`

------
https://chatgpt.com/codex/tasks/task_b_687147651be083298f5f926c5c5b0b7c