### PR TITLE
Fix cyclist alignment

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-js/togeojson.esm.js

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,16 @@
+export default [
+  {
+    ignores: ['js/togeojson.esm.js'],
+  },
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module'
+    },
+    linterOptions: {
+      reportUnusedDisableDirectives: false
+    },
+    rules: {},
+  }
+];

--- a/js/gpxLoader.js
+++ b/js/gpxLoader.js
@@ -44,7 +44,7 @@ export async function curve3D(url) {
     return new THREE.Vector3(x, y, z);
   });
 
-  const smooth = smoothPoints(points, 1);
+  const smooth = smoothPoints(points, 2);
 
   return new THREE.CatmullRomCurve3(smooth);
 }

--- a/js/physics.js
+++ b/js/physics.js
@@ -10,9 +10,24 @@ export class CyclistSim {
     this.speed = 10; // meters per second
   }
 
+  getFrameAt(u) {
+    const scaled = u * (this.frames.tangents.length - 1);
+    const i = Math.floor(scaled);
+    const t = scaled - i;
+    const next = Math.min(i + 1, this.frames.tangents.length - 1);
+    const tangent = this.frames.tangents[i]
+      .clone()
+      .lerp(this.frames.tangents[next], t)
+      .normalize();
+    const normal = this.frames.normals[i]
+      .clone()
+      .lerp(this.frames.normals[next], t)
+      .normalize();
+    return { tangent, normal };
+  }
+
   update(dt, mesh) {
-    const index = Math.floor(this.u * (this.frames.tangents.length - 1));
-    const tangent = this.frames.tangents[index];
+    const { tangent, normal } = this.getFrameAt(this.u);
     const horiz = Math.hypot(tangent.x, tangent.z);
     const slope = horiz > 0 ? tangent.y / horiz : 0;
     const accel = -9.8 * slope;
@@ -22,7 +37,7 @@ export class CyclistSim {
     this.u = Math.min(Math.max(this.u, 0), 1);
     const pos = this.curve.getPointAt(this.u);
     const lookAtPoint = pos.clone().add(tangent);
-    mesh.up.copy(this.frames.normals[index]);
+    mesh.up.copy(normal);
     mesh.position.copy(pos);
     mesh.lookAt(lookAtPoint);
   }


### PR DESCRIPTION
## Summary
- keep cyclist aligned with road using interpolated Frenet frames
- smooth the GPX curve more for gentler turns
- configure eslint for new version

## Testing
- `eslint js/physics.js js/gpxLoader.js`
- `echo "No tests" && true`


------
https://chatgpt.com/codex/tasks/task_b_6871516a4690832987dd07ce43ee3ee8