### PR TITLE
Improve GPX error handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,14 @@ light.position.set(50, 50, 50);
 scene.add(light);
 scene.add(new THREE.AmbientLight(0x666666));
 
-const track = await curve3D('assets/parcours.gpx');
+let track;
+try {
+  track = await curve3D('assets/parcours.gpx');
+} catch (err) {
+  console.error('Failed to load GPX track', err);
+  alert(err.message);
+  throw err;
+}
 const roadWidth = 12;
 const segments = 500;
 const frames = track.computeFrenetFrames(segments);

--- a/js/gpxLoader.js
+++ b/js/gpxLoader.js
@@ -30,9 +30,17 @@ function smoothPoints(points, iterations = 1) {
 
 export async function curve3D(url) {
   const res = await fetch(url);
-  const text = await res.text();
-  const xml = new DOMParser().parseFromString(text, 'application/xml');
-  const geojson = gpx(xml);
+  if (!res.ok) {
+    throw new Error(`Failed to load GPX \"${url}\": ${res.status} ${res.statusText}`);
+  }
+  let geojson;
+  try {
+    const text = await res.text();
+    const xml = new DOMParser().parseFromString(text, 'application/xml');
+    geojson = gpx(xml);
+  } catch (err) {
+    throw new Error(`Malformed GPX data: ${err.message}`);
+  }
   const coords = geojson.features[0].geometry.coordinates;
   const baseLat = coords[0][1];
   const baseLon = coords[0][0];


### PR DESCRIPTION
## Summary
- improve fetch error handling in `curve3D`
- wrap DOM parsing of GPX in try/catch
- log errors when loading GPX in `index.html`

## Testing
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_b_687164e830d083298205e6383f642403