### PR TITLE
Improve cyclist speed realism

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This project displays a 3D visualization of a cycling route using Three.js. All
 third‑party libraries are now loaded from public CDNs. The **togeojson** library
 is fetched from jsDelivr, so no local copy is required.
 
+The cyclist simulation now caps speed at 50&nbsp;km/h on flat terrain and
+automatically brakes before sharp turns.
+
 Open `index.html` in a modern browser to run the demo. Two modes are available:
 
 - **Production**: simply open `index.html`.

--- a/js/physics.js
+++ b/js/physics.js
@@ -1,6 +1,10 @@
 
 import * as THREE from 'three';
 
+const MAX_SPEED = 50 / 3.6; // 50 km/h in m/s
+const BRAKE_LOOKAHEAD = 20; // meters
+const BRAKING_FACTOR = 5; // tune braking strength
+
 export class CyclistSim {
   constructor(curve) {
     this.curve = curve;
@@ -14,8 +18,20 @@ export class CyclistSim {
     const tangent = this.curve.getTangentAt(this.u);
     const horiz = Math.hypot(tangent.x, tangent.z);
     const slope = horiz > 0 ? tangent.y / horiz : 0;
+
     const accel = -9.8 * slope;
     this.speed += accel * dt;
+
+    const lookAheadU = Math.min(
+      this.u + BRAKE_LOOKAHEAD / this.length,
+      1
+    );
+    const futureTangent = this.curve.getTangentAt(lookAheadU);
+    const angle = tangent.angleTo(futureTangent);
+    this.speed -= BRAKING_FACTOR * angle * dt;
+
+    this.speed = Math.min(Math.max(this.speed, 0), MAX_SPEED);
+
     const distance = this.speed * dt;
     this.u += distance / this.length;
     this.u = Math.min(Math.max(this.u, 0), 1);


### PR DESCRIPTION
## Summary
- limit maximum speed to 50 km/h
- add braking before turns based on curvature
- document the new behaviour

## Testing
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_b_687250b196388329bbb4446a8c935bf3