### PR TITLE
Add cyclist energy and attack UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,26 @@ canvas { width:100vw; height:100vh; display:block; touch-action:none; }
   font: 20px sans-serif;
   text-shadow: 0 0 5px #000;
 }
+#hud {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  color: #fff;
+  font: 14px sans-serif;
+  text-shadow: 0 0 5px #000;
+}
+.bar {
+  width: 200px;
+  height: 10px;
+  background: #444;
+  margin: 2px 0;
+}
+.bar > div {
+  height: 100%;
+  background: #0f0;
+  width: 100%;
+}
+#attackFill { background: #f00; }
 </style>
 <script type="importmap">
 {
@@ -28,6 +48,14 @@ canvas { width:100vw; height:100vh; display:block; touch-action:none; }
 </head>
 <body>
 <div id="speed">0 km/h | 0 m</div>
+<div id="hud">
+  <div>Énergie</div>
+  <div class="bar"><div id="energyFill"></div></div>
+  <div>Attaque</div>
+  <div class="bar"><div id="attackFill"></div></div>
+  <label>Intensité <input type="range" id="intensity" min="0" max="100" value="0"></label>
+  <button id="attackBtn">Attaquer</button>
+</div>
 <script type="module">
 import * as THREE from 'three';
 
@@ -95,6 +123,18 @@ scene.add(cyclist);
 
 const sim = new CyclistSim(track);
 const speedEl = document.getElementById('speed');
+const energyFill = document.getElementById('energyFill');
+const attackFill = document.getElementById('attackFill');
+const intensitySlider = document.getElementById('intensity');
+const attackBtn = document.getElementById('attackBtn');
+
+intensitySlider.addEventListener('input', () => {
+  sim.setIntensity(parseFloat(intensitySlider.value));
+});
+
+attackBtn.addEventListener('click', () => {
+  sim.startAttack();
+});
 
 const cameraOffset = new THREE.Vector3(0, 3, -10);
 const smoothedOffset = cameraOffset.clone();
@@ -187,6 +227,8 @@ function animate() {
   const horiz = Math.hypot(tangent.x, tangent.z);
   const slope = horiz > 0 ? (tangent.y / horiz) * 100 : 0;
   speedEl.textContent = `${(sim.speed * 3.6).toFixed(1)} km/h | ${slope.toFixed(1)}%`;
+  energyFill.style.width = `${sim.getEnergy()}%`;
+  attackFill.style.width = `${sim.getAttackEnergy()}%`;
   updateCamera(dt);
   renderer.render(scene, camera);
 }

--- a/js/physics.js
+++ b/js/physics.js
@@ -4,6 +4,10 @@ import * as THREE from 'three';
 const MAX_SPEED = 50 / 3.6; // 50 km/h in m/s
 const BRAKE_LOOKAHEAD = 20; // meters
 const BRAKING_FACTOR = 5; // tune braking strength
+const PEDAL_ACCEL = 2; // m/s^2 at full intensity
+const ENERGY_DECAY = 10; // energy units per second at full intensity
+const ATTACK_ACCEL = 5; // additional boost when attacking
+const ATTACK_DECAY = 40; // attack energy units per second
 
 export class CyclistSim {
   constructor(curve) {
@@ -11,15 +15,48 @@ export class CyclistSim {
     this.length = curve.getLength();
     this.u = 0;
     this.speed = 10; // meters per second
+    this.energy = 100; // global energy in percent
+    this.attackEnergy = 100; // energy available for attack
+    this.intensity = 0; // [0,1]
+    this.attackActive = false;
   }
 
 
+  setIntensity(percent) {
+    this.intensity = Math.min(Math.max(percent, 0), 100) / 100;
+  }
+
+  startAttack() {
+    if (this.attackEnergy > 0) {
+      this.attackActive = true;
+    }
+  }
+
+  
   update(dt, mesh) {
     const tangent = this.curve.getTangentAt(this.u);
     const horiz = Math.hypot(tangent.x, tangent.z);
     const slope = horiz > 0 ? tangent.y / horiz : 0;
 
-    const accel = -9.8 * slope;
+    let accel = -9.8 * slope;
+
+    let effort = this.intensity;
+    if (this.attackActive && this.attackEnergy > 0) {
+      accel += ATTACK_ACCEL;
+      this.attackEnergy = Math.max(this.attackEnergy - ATTACK_DECAY * dt, 0);
+      if (this.attackEnergy === 0) {
+        this.attackActive = false;
+      }
+      effort = 1; // full intensity during attack
+    }
+
+    if (this.energy > 0 && effort > 0) {
+      accel += PEDAL_ACCEL * effort;
+      this.energy = Math.max(this.energy - ENERGY_DECAY * effort * dt, 0);
+    } else if (this.energy === 0) {
+      effort = 0;
+    }
+
     this.speed += accel * dt;
 
     const lookAheadU = Math.min(
@@ -40,5 +77,13 @@ export class CyclistSim {
     const yaw = Math.atan2(dir.x, dir.z);
     mesh.position.copy(pos);
     mesh.rotation.set(0, yaw, 0);
+  }
+
+  getEnergy() {
+    return this.energy;
+  }
+
+  getAttackEnergy() {
+    return this.attackEnergy;
   }
 }


### PR DESCRIPTION
## Summary
- implement energy and attack logic in `CyclistSim`
- add HUD controls for energy, attack and intensity
- hook up attack button and slider events

## Testing
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_b_687262e1bd40832993e05e728cdb32b5