### PR TITLE
Fix module specifier imports

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,8 @@
-import * as THREE from "three";
-import * as YUKA from "yuka";
-import * as CANNON from "cannon-es";
+// Use relative paths so the application can run without a bundler.
+// These paths point to the ES module builds inside `node_modules`.
+import * as THREE from "../node_modules/three/build/three.module.js";
+import * as YUKA from "../node_modules/yuka/build/yuka.module.js";
+import * as CANNON from "../node_modules/cannon-es/dist/cannon-es.js";
 
 import { closestIdx } from "./utils.js";
 // — Scène & Caméra


### PR DESCRIPTION
## Summary
- import THREE, YUKA and CANNON using relative paths so index.html works without a bundler

## Testing
- `npx eslint .`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687662108a8c8329afd37079ce6a271e