### PR TITLE
Fix module loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Simulation de peloton de cyclisme en 3D utilisant **three.js** pour le rendu, **
 
 Le fichier `index.html` charge `src/main.js` qui instancie une scène Three.js et crée une route circulaire plate. Une trentaine d'agents sont générés et suivent cette trajectoire grâce aux comportements YUKA (suivi de chemin, séparation et cohésion). Les mouvements sont synchronisés avec un moteur physique Cannon pour gérer les collisions et les contraintes.
 
+Les dépendances (Three.js, YUKA, cannon-es) sont résolues par **Vite**. Lancez donc l'application avec `npm run dev` pour servir correctement les modules. Un simple serveur statique renverrait des erreurs 404 car le dossier `node_modules` n'est pas exposé.
+
 Une interface minimale affiche la vitesse du leader pendant la simulation.
 
 ## Utilisation

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,7 @@
-// Use relative paths so the application can run without a bundler.
-// These paths point to the ES module builds inside `node_modules`.
-import * as THREE from "../node_modules/three/build/three.module.js";
-import * as YUKA from "../node_modules/yuka/build/yuka.module.js";
-import * as CANNON from "../node_modules/cannon-es/dist/cannon-es.js";
+// Import modules via bare specifiers so Vite resolves them correctly.
+import * as THREE from "three";
+import * as YUKA from "yuka";
+import * as CANNON from "cannon-es";
 
 import { closestIdx } from "./utils.js";
 // — Scène & Caméra


### PR DESCRIPTION
## Summary
- use bare module imports so Vite handles dependencies
- document why the dev server is required

## Testing
- `npx eslint .`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68766335698c83299488faed083b9f73