### PR TITLE
Fix module loading without Vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,15 @@ Simulation de peloton de cyclisme en 3D utilisant **three.js** pour le rendu, **
 
 Le fichier `index.html` charge `src/main.js` qui instancie une scène Three.js et crée une route circulaire plate. Une trentaine d'agents sont générés et suivent cette trajectoire grâce aux comportements YUKA (suivi de chemin, séparation et cohésion). Les mouvements sont synchronisés avec un moteur physique Cannon pour gérer les collisions et les contraintes.
 
-Les dépendances (Three.js, YUKA, cannon-es) sont résolues par **Vite**. Lancez donc l'application avec `npm run dev` pour servir correctement les modules. Un simple serveur statique renverrait des erreurs 404 car le dossier `node_modules` n'est pas exposé.
+Les dépendances (Three.js, YUKA, cannon-es) sont désormais chargées directement depuis des CDN. Il suffit donc d'ouvrir `index.html` dans un navigateur, sans passer par Vite ni installer les modules Node.
 
 Une interface minimale affiche la vitesse du leader pendant la simulation.
 
 ## Utilisation
 
-- Installation des dépendances :
-
-```bash
-npm install
-```
-
-- Démarrage en mode développement :
-
-```bash
-npm run dev
-```
+Ouvrez simplement `index.html` dans votre navigateur pour lancer la simulation.
+Les scripts npm restent disponibles pour les tests et la construction si
+besoin :
 
 - Lancement des tests :
 

--- a/index.html
+++ b/index.html
@@ -24,6 +24,6 @@
   </head>
   <body>
     <div id="hud">Vitesse leader: <span id="speed">–</span> km/h</div>
-    <script type="module" src="/src/main.js"></script>
+    <script type="module" src="./src/main.js"></script>
   </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,8 @@
-// Import modules via bare specifiers so Vite resolves them correctly.
-import * as THREE from "three";
-import * as YUKA from "yuka";
-import * as CANNON from "cannon-es";
+// Import modules directement depuis des CDN afin de pouvoir ouvrir
+// `index.html` sans passer par Vite.
+import * as THREE from "https://unpkg.com/three@0.178.0/build/three.module.js";
+import * as YUKA from "https://unpkg.com/yuka@0.7.8/build/yuka.module.js";
+import * as CANNON from "https://cdn.jsdelivr.net/npm/cannon-es@0.20.0/dist/cannon-es.js";
 
 import { closestIdx } from "./utils.js";
 // — Scène & Caméra


### PR DESCRIPTION
## Summary
- load Three.js, YUKA and cannon-es from CDN
- adjust script path in `index.html`
- update README with CDN instructions

## Testing
- `npx eslint .`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687666b616048329bb074f1bace3fe4d