### PR TITLE
Fix README phrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Simulation de peloton de cyclisme en 3D utilisant **three.js** pour le rendu, **
 
 Le fichier `index.html` charge `src/main.js` qui instancie une scène Three.js et crée une route circulaire plate. Une trentaine d'agents sont générés et suivent cette trajectoire grâce aux comportements YUKA (suivi de chemin, séparation et cohésion). Les mouvements sont synchronisés avec un moteur physique Cannon pour gérer les collisions et les contraintes.
 
-Les dépendances (Three.js, YUKA, cannon-es) sont désormais chargées directement depuis des CDN. Il suffit donc d'ouvrir `index.html` dans un navigateur, sans passer par Vite ni installer les modules Node.
+Les dépendances (Three.js, YUKA, cannon-es) sont chargées directement depuis des CDN. Il suffit donc d'ouvrir `index.html` dans un navigateur, sans passer par Vite ni installer les modules Node.
 
 Une interface minimale affiche la vitesse du leader pendant la simulation.
 


### PR DESCRIPTION
## Summary
- clarify CDN loading wording in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6876766151f883299ae2b6c948eaa865