### PR TITLE
Remove npm mentions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Simulation de peloton de cyclisme en 3D utilisant **three.js** pour le rendu, **
 
 Le fichier `index.html` charge `src/main.js` qui instancie une scène Three.js et crée une route circulaire plate. Une trentaine d'agents sont générés et suivent cette trajectoire grâce aux comportements YUKA (suivi de chemin, séparation et cohésion). Les mouvements sont synchronisés avec un moteur physique Cannon pour gérer les collisions et les contraintes.
 
-Toutes les dépendances (Three.js, YUKA, cannon-es) sont fournies dans le dossier `libs/`. Le projet ne se lance donc pas avec Node mais directement dans un navigateur web. Ouvrez `index.html` depuis un petit serveur local (`npx http-server` ou `python -m http.server`) ou via `npm run dev`.
+Toutes les dépendances (Three.js, YUKA, cannon-es) sont fournies dans le dossier `libs/`. Le projet ne se lance donc pas avec Node mais directement dans un navigateur web. Ouvrez `index.html` depuis un petit serveur local (`npx http-server` ou `python -m http.server`).
 
 Une interface minimale affiche la vitesse du leader pendant la simulation.
 Un effet d'aspiration simplifié accélère les coureurs placés juste derrière un autre.
@@ -22,18 +22,4 @@ ou
 python -m http.server
 ```
 Ne lancez pas `src/main.js` directement avec Node.
-Les scripts npm restent disponibles pour les tests et la construction si
-besoin :
-
-- Lancement des tests :
-
-```bash
-npm test
-```
-
-- Construction pour la production :
-
-```bash
-npm run build
-```
 


### PR DESCRIPTION
## Summary
- remove references to npm scripts from the documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6876967a0fe48329a05075fea32328bf