### PR TITLE
Ajouter un avertissement pour le lancement local

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ python -m http.server
 ```
 Ne lancez pas `src/main.js` directement avec Node.
 
+Si la page reste vide, assurez-vous de ne pas ouvrir `index.html` directement via `file://` : le chargement des modules serait bloqué par le navigateur. Utilisez toujours un petit serveur local.
+

--- a/index.html
+++ b/index.html
@@ -24,6 +24,12 @@
   </head>
   <body>
     <div id="hud">Vitesse leader: <span id="speed">–</span> km/h</div>
+    <script>
+      if (location.protocol === 'file:') {
+        document.body.innerHTML =
+          'Veuillez lancer un petit serveur local (par exemple <code>npx http-server</code>) pour exécuter la simulation.'
+      }
+    </script>
     <script type="module" src="./src/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- afficher un message si la page est chargée via `file://`
- préciser dans le README qu'il faut utiliser un serveur local

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6876a62cd96c8329a5326b7af88de46a