### PR TITLE
Adjust rider width to reduce overlap

### DIFF
--- a/src/riders.js
+++ b/src/riders.js
@@ -18,13 +18,15 @@ const teamColors = Array.from({ length: NUM_TEAMS }, (_, i) => {
   return c;
 });
 const riderGeom = new THREE.BoxGeometry(1.7, 1.5, 0.5);
+// Collision shape radius for Cannon.js bodies
+const RIDER_COLLISION_RADIUS = 0.85;
 
 const riders = [];
 
 for (let team = 0; team < NUM_TEAMS; team++) {
   const mat = new THREE.MeshLambertMaterial({ color: teamColors[team] });
   for (let i = 0; i < RIDERS_PER_TEAM; i++) {
-    const RIDER_WIDTH = 1.3;
+    const RIDER_WIDTH = 1.7;
     const MIN_LATERAL_GAP = 0.3;
     const spacing = RIDER_WIDTH + MIN_LATERAL_GAP;
     const ridersPerRow = Math.max(1, Math.floor(ROAD_WIDTH / spacing));
@@ -47,7 +49,7 @@ for (let team = 0; team < NUM_TEAMS; team++) {
     scene.add(mesh);
 
     const body = new CANNON.Body({ mass: 1 });
-    body.addShape(new CANNON.Sphere(0.25));
+    body.addShape(new CANNON.Sphere(RIDER_COLLISION_RADIUS));
     body.position.set(x0, 0, z0);
     world.addBody(body);
 


### PR DESCRIPTION
## Summary
- enlarge rider collision radius
- use rider width that matches geometry to space them farther apart

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6879530fbb5483299ef5e51ea6ec2f4d