### PR TITLE
Improve rider side collision handling

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -244,6 +244,12 @@ function animate() {
     const lookAtPoint = new THREE.Vector3(r.mesh.position.x + dx, 0, r.mesh.position.z + dz);
     r.mesh.lookAt(lookAtPoint);
     r.mesh.rotateY(-Math.PI / 2);
+    r.body.quaternion.set(
+      r.mesh.quaternion.x,
+      r.mesh.quaternion.y,
+      r.mesh.quaternion.z,
+      r.mesh.quaternion.w
+    );
   });
 
   updateSelectionHelper();

--- a/src/riders.js
+++ b/src/riders.js
@@ -21,8 +21,12 @@ const riderGeom = new THREE.BoxGeometry(1.7, 1.5, 0.5);
 
 const RIDER_WIDTH = 1.7; // match geometry width
 const MIN_LATERAL_GAP = 0.5;
-// Collision shape radius for Cannon.js bodies
-const RIDER_COLLISION_RADIUS = 1.0;
+// Collision body dimensions for Cannon.js bodies
+const RIDER_BOX_HALF = {
+  x: riderGeom.parameters.width / 2,
+  y: riderGeom.parameters.height / 2,
+  z: riderGeom.parameters.depth / 2
+};
 const riders = [];
 
 for (let team = 0; team < NUM_TEAMS; team++) {
@@ -50,7 +54,12 @@ for (let team = 0; team < NUM_TEAMS; team++) {
     scene.add(mesh);
 
     const body = new CANNON.Body({ mass: 1 });
-    body.addShape(new CANNON.Sphere(RIDER_COLLISION_RADIUS));
+    const halfExtents = new CANNON.Vec3(
+      RIDER_BOX_HALF.x,
+      RIDER_BOX_HALF.y,
+      RIDER_BOX_HALF.z
+    );
+    body.addShape(new CANNON.Box(halfExtents));
     body.position.set(x0, 0, z0);
     world.addBody(body);
 


### PR DESCRIPTION
## Summary
- use a box collision shape for riders instead of a sphere
- keep physics body orientation in sync with the visible rider mesh

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687a46678d548329b2723167204c09d7