### PR TITLE
Fix chaotic start

### DIFF
--- a/src/startButton.js
+++ b/src/startButton.js
@@ -1,8 +1,5 @@
 import { riders } from './riders.js';
-import { TRACK_WRAP } from './track.js';
 import { polarToDist } from './utils.js';
-
-const BASE_SPEED = 8;
 
 let started = false;
 
@@ -12,10 +9,7 @@ if (startBtn) {
     started = true;
     riders.forEach(r => {
       r.currentBoost = 0;
-      const theta = (polarToDist(r.body.position.x, r.body.position.z) / TRACK_WRAP) * 2 * Math.PI;
-      const vx = -Math.sin(theta) * BASE_SPEED;
-      const vz = Math.cos(theta) * BASE_SPEED;
-      r.body.velocity.set(vx, 0, vz);
+      r.body.velocity.set(0, 0, 0);
       r.mesh.position.copy(r.body.position);
       r.trackDist = polarToDist(r.body.position.x, r.body.position.z);
     });


### PR DESCRIPTION
## Summary
- start riders from rest when clicking the Start button

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687a487b204c83299e8a269c3e9c5ea2