### PR TITLE
Add intensity and relay rotation

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -1,6 +1,6 @@
 import { THREE, scene, camera, renderer } from './setupScene.js';
 import { CANNON } from './physicsWorld.js';
-import { riders, boidSystem } from './riders.js';
+import { riders, boidSystem, teamRelayState } from './riders.js';
 import {
   outerSpline,
   innerSpline,
@@ -23,6 +23,9 @@ const RELAY_SPEED_BOOST = 0.5;
 const LATERAL_FORCE = 5;
 const MAX_LANE_OFFSET = ROAD_WIDTH / 2 - 0.85;
 const LANE_CHANGE_SPEED = 2;
+const RELAY_INTERVAL = 5;
+const PULL_OFF_TIME = 2;
+const PULL_OFFSET = 1.5;
 
 const forwardVec = new THREE.Vector3();
 const lookAtPt = new THREE.Vector3();
@@ -95,6 +98,41 @@ function updateLaneOffsets(dt) {
   });
 }
 
+function updateRelays(dt) {
+  for (let t = 0; t < teamRelayState.length; t++) {
+    const state = teamRelayState[t];
+    const teamRiders = riders.filter(r => r.team === t && r.relaySetting > 0);
+    if (teamRiders.length === 0) continue;
+
+    teamRiders.sort((a, b) => b.trackDist - a.trackDist);
+    const leader = teamRiders[state.index % teamRiders.length];
+    teamRiders.forEach(r => {
+      r.relayIntensity = 0;
+    });
+    leader.relayIntensity = leader.relaySetting;
+
+    state.timer += dt;
+    if (state.timer >= RELAY_INTERVAL) {
+      state.timer = 0;
+      leader.pullingOff = true;
+      leader.pullTimer = 0;
+      leader.laneTarget = state.side * PULL_OFFSET;
+      state.index = (state.index + 1) % teamRiders.length;
+      state.side *= -1;
+    }
+  }
+
+  riders.forEach(r => {
+    if (r.pullingOff) {
+      r.pullTimer += dt;
+      if (r.pullTimer >= PULL_OFF_TIME) {
+        r.pullingOff = false;
+        r.laneTarget = 0;
+      }
+    }
+  });
+}
+
 function applyForces(dt) {
   const stretch = computeStretch();
   riders.forEach(r => {
@@ -104,7 +142,7 @@ function applyForces(dt) {
         : r.relayIntensity * RELAY_SPEED_BOOST;
 
     // Determine if this rider is blocked by another rider directly ahead
-    if (r.relayIntensity > 0) {
+    if (r.relayIntensity > 0 && !r.pullingOff) {
       const SAFE_DIST = 4;
       const LANE_GAP = 1.2;
       let blocked = false;
@@ -145,7 +183,7 @@ function applyForces(dt) {
       } else {
         r.laneTarget = 0;
       }
-    } else {
+    } else if (!r.pullingOff) {
       r.laneTarget = 0;
     }
 
@@ -210,7 +248,8 @@ function animate() {
       const theta = (polarToDist(r.body.position.x, r.body.position.z) / TRACK_WRAP) * 2 * Math.PI;
       const forward = new CANNON.Vec3(-Math.sin(theta), 0, Math.cos(theta));
       const currentSpeed = r.body.velocity.length();
-      const speedDiff = BASE_SPEED - currentSpeed;
+      const desiredSpeed = BASE_SPEED * (r.intensity / 50);
+      const speedDiff = desiredSpeed - currentSpeed;
       const accel = speedDiff * SPEED_GAIN;
       const accelForce = forward.scale(r.body.mass * accel);
       r.body.applyForce(accelForce, r.body.position);
@@ -219,6 +258,7 @@ function animate() {
 
   clampAndRedirect();
   updateLaneOffsets(dt);
+  updateRelays(dt);
   applyForces(dt);
   boidSystem.update(dt);
 

--- a/src/riders.js
+++ b/src/riders.js
@@ -28,6 +28,11 @@ const RIDER_BOX_HALF = {
   z: riderGeom.parameters.depth / 2
 };
 const riders = [];
+const teamRelayState = Array.from({ length: NUM_TEAMS }, () => ({
+  index: 0,
+  timer: 0,
+  side: 1
+}));
 
 for (let team = 0; team < NUM_TEAMS; team++) {
   const mat = new THREE.MeshLambertMaterial({ color: teamColors[team] });
@@ -76,7 +81,11 @@ for (let team = 0; team < NUM_TEAMS; team++) {
       laneTarget: off,
       speed: 0,
       energy: 100,
+      relaySetting: 0,
       relayIntensity: 0,
+      intensity: 50,
+      pullingOff: false,
+      pullTimer: 0,
       protectLeader: false,
       effortMode: 1,
       mesh,
@@ -86,4 +95,4 @@ for (let team = 0; team < NUM_TEAMS; team++) {
   }
 }
 
-export { boidSystem, riders, teamColors, riderGeom };
+export { boidSystem, riders, teamColors, riderGeom, teamRelayState };

--- a/src/ui.js
+++ b/src/ui.js
@@ -36,7 +36,7 @@ function showTeamControls(tid) {
     riders
       .filter(r => r.team === tid)
       .forEach((r, idx) => {
-        r.relayIntensity = lvl;
+        r.relaySetting = lvl;
         const sel = document.getElementById(`relay_${tid}_${idx}`);
         if (sel) sel.value = lvl;
       });
@@ -50,11 +50,13 @@ function showTeamControls(tid) {
       row.innerHTML = `
       <span>Rider ${idx + 1}${r.isLeader ? ' (Leader)' : ''}</span>
       <label>Relay:<select id="relay_${tid}_${idx}"><option>0</option><option>1</option><option>2</option><option>3</option></select></label>
+      <label>Intensity:<input type="range" min="0" max="100" id="int_${tid}_${idx}" value="${r.intensity}"/></label>
       <label><input type="checkbox" id="prot_${tid}_${idx}" ${r.protectLeader ? 'checked' : ''} ${r.isLeader ? 'disabled' : ''}/> Protect</label>
       <label>Effort:<select id="eff_${tid}_${idx}"><option value="0">Follower</option><option value="1">Normal</option><option value="2">Attack</option></select></label>`;
       teamControlsDiv.append(row);
-      document.getElementById(`relay_${tid}_${idx}`).value = r.relayIntensity;
-      document.getElementById(`relay_${tid}_${idx}`).addEventListener('change', e => (r.relayIntensity = +e.target.value));
+      document.getElementById(`relay_${tid}_${idx}`).value = r.relaySetting;
+      document.getElementById(`relay_${tid}_${idx}`).addEventListener('change', e => (r.relaySetting = +e.target.value));
+      document.getElementById(`int_${tid}_${idx}`).addEventListener('input', e => (r.intensity = +e.target.value));
       document.getElementById(`prot_${tid}_${idx}`).addEventListener('change', e => (r.protectLeader = e.target.checked));
       document.getElementById(`eff_${tid}_${idx}`).value = r.effortMode;
       document.getElementById(`eff_${tid}_${idx}`).addEventListener('change', e => (r.effortMode = +e.target.value));

--- a/style.css
+++ b/style.css
@@ -39,3 +39,7 @@ body {
 .rider-control label {
     margin-right: 10px;
 }
+
+input[type='range'] {
+    width: 80px;
+}


### PR DESCRIPTION
## Summary
- allow adjusting rider intensity via UI
- rotate relay leaders so riders take turns
- style slider for intensity control

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687a46daa4708329bfdf8b3a9bd13e07