### PR TITLE
Improve rider collision avoidance

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -1,6 +1,11 @@
 import { THREE, scene, camera, renderer } from './setupScene.js';
 import { CANNON } from './physicsWorld.js';
-import { riders, boidSystem } from './riders.js';
+import {
+  riders,
+  boidSystem,
+  RIDER_WIDTH,
+  MIN_LATERAL_GAP
+} from './riders.js';
 import {
   outerSpline,
   innerSpline,
@@ -165,6 +170,31 @@ function applyForces(dt) {
   });
 }
 
+function resolveOverlaps() {
+  const minDist = RIDER_WIDTH + MIN_LATERAL_GAP;
+  for (let i = 0; i < riders.length; i++) {
+    const a = riders[i];
+    for (let j = i + 1; j < riders.length; j++) {
+      const b = riders[j];
+      const dx = a.body.position.x - b.body.position.x;
+      const dz = a.body.position.z - b.body.position.z;
+      const distSq = dx * dx + dz * dz;
+      if (distSq < minDist * minDist && distSq > 1e-6) {
+        const dist = Math.sqrt(distSq);
+        const overlap = minDist - dist;
+        const nx = dx / dist;
+        const nz = dz / dist;
+        const pushX = nx * (overlap / 2);
+        const pushZ = nz * (overlap / 2);
+        a.body.position.x += pushX;
+        a.body.position.z += pushZ;
+        b.body.position.x -= pushX;
+        b.body.position.z -= pushZ;
+      }
+    }
+  }
+}
+
 function updateCamera() {
   let tx, tz, ang;
   if (selectedIndex !== null) {
@@ -216,6 +246,7 @@ function animate() {
   clampAndRedirect();
   updateLaneOffsets(dt);
   applyForces(dt);
+  resolveOverlaps();
   boidSystem.update(dt);
 
   riders.forEach(r => {

--- a/src/riders.js
+++ b/src/riders.js
@@ -88,4 +88,11 @@ for (let team = 0; team < NUM_TEAMS; team++) {
   }
 }
 
-export { boidSystem, riders, teamColors, riderGeom };
+export {
+  boidSystem,
+  riders,
+  teamColors,
+  riderGeom,
+  RIDER_WIDTH,
+  MIN_LATERAL_GAP
+};


### PR DESCRIPTION
## Summary
- export rider sizing constants
- prevent riders from overlapping by resolving collisions each frame

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687a48e622348329a96f08eb6a7a421a