### PR TITLE
Add version bump workflow and version display

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,27 @@
+name: Bump version on merge
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  bump:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.base.ref }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Bump version
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+          npm version patch -m "chore: bump version to %s [skip ci]"
+          git push --follow-tags origin HEAD:${{ github.event.pull_request.base.ref }}

--- a/index.html
+++ b/index.html
@@ -47,6 +47,15 @@
 
     <!-- Ton script principal en module (importe Three.js, Cannon‑ES, bird‑oid/Boids, etc.) -->
     <script type="module" src="src/main.js"></script>
+
+    <div id="version-container">Version: <span id="version"></span></div>
+    <script>
+      fetch('package.json')
+        .then(r => r.json())
+        .then(pkg => {
+          document.getElementById('version').textContent = 'v' + pkg.version;
+        });
+    </script>
 </body>
 
 </html>

--- a/style.css
+++ b/style.css
@@ -43,3 +43,12 @@ body {
 input[type='range'] {
     width: 80px;
 }
+
+#version-container {
+    position: fixed;
+    bottom: 5px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.8em;
+    color: #ccc;
+}


### PR DESCRIPTION
## Summary
- automatically bump patch version when a PR is merged
- show the package version at the bottom of the page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687a4b197d0883299667a7737b8d37c6