### PR TITLE
Fix boid state reset when starting simulation

### DIFF
--- a/src/startButton.js
+++ b/src/startButton.js
@@ -14,6 +14,10 @@ if (startBtn) {
       r.trackDist = polarToDist(r.body.position.x, r.body.position.z);
       r.prevDist = r.trackDist;
       r.lap = 0;
+      if (r.boid) {
+        r.boid.position = [r.body.position.x, r.body.position.z];
+        r.boid.velocity = [0, 0];
+      }
     });
     startBtn.disabled = true;
   });


### PR DESCRIPTION
## Summary
- reset boid position and velocity on Start button click so the boid system doesn't push riders apart

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687a4c9a1e28832984ec3fb6440308ef