### PR TITLE
Dynamic width adjustment

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -73,8 +73,13 @@ function computeStretch() {
       leader = r;
     }
   });
-  const intensity = leader.relayIntensity || 0;
-  return Math.min(1, 0.2 + 0.2 * intensity);
+
+  // Stretch the peloton according to the speed of the leading rider.
+  // A faster leader narrows the width of the group.
+  const leaderSpeed = leader.body.velocity.length();
+  const speedFactor = leaderSpeed / BASE_SPEED;
+  const stretch = Math.min(1, 0.1 + 0.5 * Math.max(0, speedFactor - 1));
+  return stretch;
 }
 
 function updateLaneOffsets(dt) {

--- a/src/riders.js
+++ b/src/riders.js
@@ -20,7 +20,8 @@ const teamColors = Array.from({ length: NUM_TEAMS }, (_, i) => {
 const riderGeom = new THREE.BoxGeometry(1.7, 1.5, 0.5);
 
 const RIDER_WIDTH = 1.7; // match geometry width
-const MIN_LATERAL_GAP = 0.5;
+// Reduced gap to fit more riders across the road at base speed
+const MIN_LATERAL_GAP = 0.3;
 // Collision body dimensions for Cannon.js bodies
 const RIDER_BOX_HALF = {
   x: riderGeom.parameters.width / 2,


### PR DESCRIPTION
## Summary
- riders start closer together with a smaller lateral gap
- narrow the peloton width as the leading rider gains speed

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687a4ce5d1548329b8eaf7583150d75c