### PR TITLE
Fix version display docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Cette simulation affiche un peloton de cyclistes en 3D dans votre navigateur. Le
 
 ## Utilisation
 Ouvrez `index.html` dans un navigateur moderne. Le fichier charge automatiquement les modules nécessaires via des imports ES modules et utilise des bibliothèques depuis un CDN.
+Pour que l'affichage de la version fonctionne, servez ce dossier via un serveur HTTP local (par ex. `npx http-server` ou `python -m http.server`) puis ouvrez la page depuis `http://localhost:8080`. L'ouverture directe du fichier risque d'empêcher la lecture de `package.json`.
 
 ## Développement
 Les dépendances de développement (ESLint) sont gérées via `npm`. Pour vérifier le linting et exécuter le jeu de tests factice :

--- a/index.html
+++ b/index.html
@@ -53,7 +53,8 @@
       fetch('package.json')
         .then(r => r.json())
         .then(pkg => {
-          document.getElementById('version').textContent = 'v' + pkg.version;
+          const major = pkg.version.split('.')[0];
+          document.getElementById('version').textContent = 'v' + major;
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- explain how to serve the project locally so `package.json` can be fetched
- display only the major version number from `package.json`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687a4c5e3d648329ace94feeaa493039