### PR TITLE
Fix rider scattering on start

### DIFF
--- a/src/riders.js
+++ b/src/riders.js
@@ -67,6 +67,8 @@ for (let team = 0; team < NUM_TEAMS; team++) {
     );
     body.addShape(new CANNON.Box(halfExtents));
     body.position.set(x0, 0, z0);
+    body.linearDamping = 0.2;
+    body.angularDamping = 0.2;
     world.addBody(body);
 
     const boid = new Boid(boidBehaviors);

--- a/src/startButton.js
+++ b/src/startButton.js
@@ -10,6 +10,9 @@ if (startBtn) {
     riders.forEach(r => {
       r.currentBoost = 0;
       r.body.velocity.set(0, 0, 0);
+      r.body.angularVelocity.set(0, 0, 0);
+      r.body.force.set(0, 0, 0);
+      r.body.torque.set(0, 0, 0);
       r.mesh.position.copy(r.body.position);
       r.trackDist = polarToDist(r.body.position.x, r.body.position.z);
       r.prevDist = r.trackDist;


### PR DESCRIPTION
## Summary
- stabilize riders by adding linear and angular damping
- reset all body dynamics on start for consistent peloton formation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687a4f274f6483299924eed50a973513