### PR TITLE
Fix bump version workflow trigger

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,7 +1,7 @@
 name: Bump version on merge
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
 


### PR DESCRIPTION
## Summary
- update `bump-version.yml` to use `pull_request_target`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687a755358d48329a17e06a44d2f453d