### PR TITLE
Fix bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -5,12 +5,14 @@ on:
     types:
       - closed
 
+permissions:
+  pull-requests: write
+  contents:       write
+
 jobs:
   bump:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -36,3 +38,4 @@ jobs:
           git add version.json
           git commit -m "chore: bump version to v${version} [skip ci]"
           git push origin HEAD:${{ github.event.pull_request.base.ref }}
+


### PR DESCRIPTION
## Summary
- copy permission settings from `automerge.yml` to the bump version workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687b59ed9a4c8329bda1f0eee3a80949