### PR TITLE
Automated version bump on main push

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,9 +1,9 @@
 name: Bump version on merge
 
 on:
-  pull_request_target:
-    types:
-      - closed
+  push:
+    branches:
+      - main
 
 permissions:
   pull-requests: write
@@ -11,13 +11,12 @@ permissions:
 
 jobs:
   bump:
-    if: github.event.pull_request.merged == true
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ github.event.pull_request.base.ref }}
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -37,5 +36,5 @@ jobs:
           )
           git add version.json
           git commit -m "chore: bump version to v${version} [skip ci]"
-          git push origin HEAD:${{ github.event.pull_request.base.ref }}
+          git push origin HEAD:main
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Cette simulation affiche un peloton de cyclistes en 3D dans votre navigateur. Le
 ## Utilisation
 Ouvrez `index.html` dans un navigateur moderne. Le fichier charge automatiquement les modules nécessaires via des imports ES modules et utilise des bibliothèques depuis un CDN.
 Pour que l'affichage de la version fonctionne, servez ce dossier via un serveur HTTP local (par ex. `npx http-server` ou `python -m http.server`) puis ouvrez la page depuis `http://localhost:8080`. L'ouverture directe du fichier risque d'empêcher la lecture de `version.json`.
-Le numéro de version courant est stocké dans le fichier `version.json` à la racine du projet.
+Le numéro de version courant est stocké dans le fichier `version.json` à la racine du projet. Il est incrémenté automatiquement lorsqu'une pull request est fusionnée dans `main` grâce au workflow GitHub fourni.
 
 ## Développement
 Les dépendances de développement (ESLint) sont gérées via `npm`. Pour vérifier le linting et exécuter le jeu de tests factice :


### PR DESCRIPTION
## Summary
- trigger bump-version workflow on every push to `main`
- document automatic version bump in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687b6340854c8329b129060b1c5eab1a