### PR TITLE
Allow full width at base speed

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -129,7 +129,11 @@ function computeStretch() {
   // A faster leader narrows the width of the group.
   const leaderSpeed = leader.body.velocity.length();
   const speedFactor = leaderSpeed / BASE_SPEED;
-  const stretch = Math.min(1, 0.1 + 0.5 * Math.max(0, speedFactor - 1));
+
+  // At or below base speed allow riders to occupy the full width
+  if (speedFactor <= 1) return 0;
+
+  const stretch = Math.min(1, 0.1 + 0.5 * (speedFactor - 1));
   return stretch;
 }
 


### PR DESCRIPTION
## Summary
- spread riders across the entire road when peloton moves at base speed

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687b64b7c2088329b81141a586d7dc58