### PR TITLE
Fix overlap of riders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.4",
+      "version": "1.0.6",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^9.31.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "simulation.js",
   "scripts": {

--- a/src/animation.js
+++ b/src/animation.js
@@ -284,37 +284,43 @@ function applyForces(dt) {
  */
 function resolveOverlaps() {
   const minDist = RIDER_WIDTH + MIN_LATERAL_GAP;
-  for (let i = 0; i < riders.length; i++) {
-    const a = riders[i];
-    for (let j = i + 1; j < riders.length; j++) {
-      const b = riders[j];
-      const dx = a.body.position.x - b.body.position.x;
-      const dz = a.body.position.z - b.body.position.z;
-      const distSq = dx * dx + dz * dz;
-      if (distSq < minDist * minDist && distSq > 1e-6) {
-        const dist = Math.sqrt(distSq);
-        const overlap = minDist - dist;
-        const nx = dx / dist;
-        const nz = dz / dist;
-        const pushX = nx * (overlap / 2);
-        const pushZ = nz * (overlap / 2);
-        a.body.position.x += pushX;
-        a.body.position.z += pushZ;
-        b.body.position.x -= pushX;
-        b.body.position.z -= pushZ;
+  // Iterate a few times to resolve chains of overlaps
+  for (let pass = 0; pass < 3; pass++) {
+    let moved = false;
+    for (let i = 0; i < riders.length; i++) {
+      const a = riders[i];
+      for (let j = i + 1; j < riders.length; j++) {
+        const b = riders[j];
+        const dx = a.body.position.x - b.body.position.x;
+        const dz = a.body.position.z - b.body.position.z;
+        const distSq = dx * dx + dz * dz;
+        if (distSq < minDist * minDist && distSq > 1e-6) {
+          const dist = Math.sqrt(distSq);
+          const overlap = minDist - dist;
+          const nx = dx / dist;
+          const nz = dz / dist;
+          const pushX = nx * (overlap / 2);
+          const pushZ = nz * (overlap / 2);
+          a.body.position.x += pushX;
+          a.body.position.z += pushZ;
+          b.body.position.x -= pushX;
+          b.body.position.z -= pushZ;
+          moved = true;
 
-        const relVX = a.body.velocity.x - b.body.velocity.x;
-        const relVZ = a.body.velocity.z - b.body.velocity.z;
-        const relVN = relVX * nx + relVZ * nz;
-        if (relVN < 0) {
-          const impulse = relVN / 2;
-          a.body.velocity.x -= impulse * nx;
-          a.body.velocity.z -= impulse * nz;
-          b.body.velocity.x += impulse * nx;
-          b.body.velocity.z += impulse * nz;
+          const relVX = a.body.velocity.x - b.body.velocity.x;
+          const relVZ = a.body.velocity.z - b.body.velocity.z;
+          const relVN = relVX * nx + relVZ * nz;
+          if (relVN < 0) {
+            const impulse = relVN / 2;
+            a.body.velocity.x -= impulse * nx;
+            a.body.velocity.z -= impulse * nz;
+            b.body.velocity.x += impulse * nx;
+            b.body.velocity.z += impulse * nz;
+          }
         }
       }
     }
+    if (!moved) break;
   }
 }
 


### PR DESCRIPTION
## Summary
- prevent riders from overlapping by resolving multiple passes
- bump version to 1.0.6

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687e29ed90d4832996b4307d790c6610