### PR TITLE
Fix rider slowdown at start

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "simulation.js",
   "scripts": {

--- a/src/animation.js
+++ b/src/animation.js
@@ -23,8 +23,8 @@ import { stepPhysics } from './physicsWorld.js';
 import { updateSelectionHelper, selectedIndex } from './ui.js';
 import { started } from './startButton.js';
 import { aheadDistance, wrapDistance } from './utils.js';
+import { BASE_SPEED } from './constants.js';
 
-const BASE_SPEED = 8;
 const SPEED_GAIN = 0.3;
 // Mix less with the ideal line so physical collisions have more influence
 const IDEAL_MIX = 0.3;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,4 @@
+// Constantes partagées entre plusieurs modules
+const BASE_SPEED = 8;
+
+export { BASE_SPEED };

--- a/src/startButton.js
+++ b/src/startButton.js
@@ -2,6 +2,7 @@
 
 import { riders } from './riders.js';
 import { polarToDist } from './utils.js';
+import { BASE_SPEED } from './constants.js';
 
 let started = false;
 
@@ -14,7 +15,12 @@ if (startBtn) {
       r.isAttacking = false;
       r.attackGauge = 100;
       r.intensity = r.baseIntensity;
-      r.body.velocity.set(0, 0, 0);
+      const angle = Math.atan2(r.body.position.z, r.body.position.x);
+      r.body.velocity.set(
+        -Math.sin(angle) * BASE_SPEED,
+        0,
+        Math.cos(angle) * BASE_SPEED
+      );
       r.body.angularVelocity.set(0, 0, 0);
       r.body.force.set(0, 0, 0);
       r.body.torque.set(0, 0, 0);
@@ -24,7 +30,10 @@ if (startBtn) {
       r.lap = 0;
       if (r.boid) {
         r.boid.position = [r.body.position.x, r.body.position.z];
-        r.boid.velocity = [0, 0];
+        r.boid.velocity = [
+          -Math.sin(angle) * BASE_SPEED,
+          Math.cos(angle) * BASE_SPEED
+        ];
       }
     });
     startBtn.disabled = true;


### PR DESCRIPTION
## Summary
- keep riders moving as soon as the start button is pressed
- share `BASE_SPEED` via new constants module
- use shared constant in animation logic
- bump version to 1.0.6

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687e2a13f1a8832985850f21b8e6e760