### PR TITLE
Implement leader intensity following

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.6",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.6",
+      "version": "1.0.9",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^9.31.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "",
   "main": "simulation.js",
   "scripts": {

--- a/src/animation.js
+++ b/src/animation.js
@@ -198,6 +198,22 @@ function updateRelays(dt) {
 }
 
 /**
+ * Adapte l'intensité des coureurs au leader lorsqu'il roule au maximum.
+ *
+ * @returns {void}
+ */
+function adjustIntensityToLeader() {
+  const leader = riders.reduce((a, b) => (b.trackDist > a.trackDist ? b : a), riders[0]);
+  if (leader.isAttacking || leader.intensity < 100) return;
+
+  riders.forEach(r => {
+    if (r !== leader && !r.isAttacking) {
+      r.intensity = Math.max(r.intensity, leader.intensity);
+    }
+  });
+}
+
+/**
  * Applique les différentes forces physiques sur les coureurs.
  *
  * @param {number} dt Durée écoulée depuis la dernière mise à jour en secondes.
@@ -394,6 +410,8 @@ function animate() {
         r.intensity = r.baseIntensity;
       }
     });
+
+    adjustIntensityToLeader();
 
     riders.forEach(r => {
       const theta = ((r.trackDist % TRACK_WRAP) / TRACK_WRAP) * 2 * Math.PI;


### PR DESCRIPTION
## Summary
- implement `adjustIntensityToLeader` so riders follow the peloton leader when they ride at max intensity
- hook this logic in the animation loop
- bump version to 1.0.9

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687e33c96ed0832997a47da6b84c854a