### PR TITLE
Fix slowdown at start line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^9.31.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "",
   "main": "simulation.js",
   "scripts": {

--- a/src/track.js
+++ b/src/track.js
@@ -18,8 +18,13 @@ road.rotation.x = -Math.PI / 2;
 scene.add(road);
 
 const trackPoints = [];
-for (let a = 0; a <= Math.PI * 2; a += 0.1) {
-  trackPoints.push(new THREE.Vector3(BASE_RADIUS * Math.cos(a), 0, BASE_RADIUS * Math.sin(a)));
+// Avoid duplicating the first point at 2π which introduced a sharp corner on the
+// center spline and caused riders to slow down each lap when crossing the
+// start/finish line.
+for (let a = 0; a < Math.PI * 2; a += 0.1) {
+  trackPoints.push(
+    new THREE.Vector3(BASE_RADIUS * Math.cos(a), 0, BASE_RADIUS * Math.sin(a))
+  );
 }
 const centerSpline = new THREE.CatmullRomCurve3(trackPoints, true);
 


### PR DESCRIPTION
## Summary
- smooth out track spline to remove duplicate point at 2π
- bump version to 1.0.10

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687e343c5f188329ae1de2e818f114d7