### PR TITLE
Improve relay chasing logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^9.31.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "",
   "main": "simulation.js",
   "scripts": {

--- a/src/animation.js
+++ b/src/animation.js
@@ -45,6 +45,8 @@ const PULL_OFF_SPEED_FACTOR = 0.7;
 const ATTACK_INTENSITY = 60; // 120% of base intensity
 const ATTACK_DRAIN = 50; // gauge units per second during attack
 const ATTACK_RECOVERY = 10; // gauge recovery per second
+const RELAY_QUEUE_GAP = 4;
+const RELAY_CHASE_INTENSITY = 70;
 
 const forwardVec = new THREE.Vector3();
 const lookAtPt = new THREE.Vector3();
@@ -172,8 +174,16 @@ function updateRelays(dt) {
     const leader = teamRiders[state.index % teamRiders.length];
     teamRiders.forEach(r => {
       r.relayIntensity = 0;
+      r.relayChasing = false;
     });
     leader.relayIntensity = leader.relaySetting;
+
+    for (let i = 1; i < teamRiders.length; i++) {
+      const prev = teamRiders[i - 1];
+      const r = teamRiders[i];
+      const dist = aheadDistance(r.trackDist, prev.trackDist);
+      if (dist > RELAY_QUEUE_GAP) r.relayChasing = true;
+    }
 
     state.timer += dt;
     if (state.timer >= RELAY_INTERVAL) {
@@ -408,6 +418,9 @@ function animate() {
       } else {
         r.attackGauge = Math.min(100, r.attackGauge + ATTACK_RECOVERY * dt);
         r.intensity = r.baseIntensity;
+        if (r.relayChasing) {
+          r.intensity = Math.max(r.intensity, RELAY_CHASE_INTENSITY);
+        }
       }
     });
 

--- a/src/riders.js
+++ b/src/riders.js
@@ -108,6 +108,7 @@ for (let team = 0; team < NUM_TEAMS; team++) {
       relayIntensity: 0,
       baseIntensity: 50,
       intensity: 50,
+      relayChasing: false,
       pullingOff: false,
       pullTimer: 0,
       protectLeader: false,


### PR DESCRIPTION
## Summary
- boost relay riders so they accelerate to join the queue
- bump version to 1.0.11

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687e9f55dc3c8329a5d9acf8f920d71e