### PR TITLE
Fix rider spacing by widening track

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "",
   "main": "simulation.js",
   "scripts": {

--- a/src/track.js
+++ b/src/track.js
@@ -3,7 +3,8 @@
 import { THREE, scene } from './setupScene.js';
 
 const TRACK_LENGTH = 1000;
-const ROAD_WIDTH = 10;
+// Slightly widen the road so six riders can fit side by side
+const ROAD_WIDTH = 12;
 const BASE_RADIUS = TRACK_LENGTH / (2 * Math.PI);
 const INNER_R = BASE_RADIUS - ROAD_WIDTH / 2;
 const OUTER_R = BASE_RADIUS + ROAD_WIDTH / 2;


### PR DESCRIPTION
## Summary
- widen the roadway to 12 units so six cyclists can line up abreast
- bump version number

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687ff832e5c883299da36cd4f9a9bc1b