### PR TITLE
Reduce lateral gap for riders

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "",
   "main": "simulation.js",
   "scripts": {

--- a/src/riders.js
+++ b/src/riders.js
@@ -22,9 +22,8 @@ const teamColors = Array.from({ length: NUM_TEAMS }, (_, i) => {
 const riderGeom = new THREE.BoxGeometry(1.7, 1.5, 0.5);
 
 const RIDER_WIDTH = 1.7; // match geometry width
-// Reduced gap to fit more riders across the road at base speed
-// Slightly smaller gap so more riders fit side by side
-const MIN_LATERAL_GAP = 0.2;
+// Allow riders to be tightly packed
+const MIN_LATERAL_GAP = 0;
 // Collision body dimensions for Cannon.js bodies
 // Swap width/depth so side collisions use the long face of the box
 const RIDER_BOX_HALF = {


### PR DESCRIPTION
## Summary
- allow riders to be packed tightly by setting `MIN_LATERAL_GAP` to zero
- bump version to 1.0.14

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687ffb948d308329bbeeb66c49a9576d