### PR TITLE
Fix rider spacing with safe lateral gap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.13",
+  "version": "1.0.15",
   "description": "",
   "main": "simulation.js",
   "scripts": {

--- a/src/animation.js
+++ b/src/animation.js
@@ -35,7 +35,7 @@ const MAX_SPEED = BASE_SPEED * 2;
 // Limit side movement so riders don't slide across the road too quickly
 // Limit side movement speed
 const MAX_LATERAL_SPEED = 3;
-const MAX_LANE_OFFSET = ROAD_WIDTH / 2 - 0.85;
+const MAX_LANE_OFFSET = ROAD_WIDTH / 2 - RIDER_WIDTH / 2 - MIN_LATERAL_GAP / 2;
 // Slow down lane changes for smoother overtaking
 const LANE_CHANGE_SPEED = 1.5;
 const BASE_RELAY_INTERVAL = 5;

--- a/src/riders.js
+++ b/src/riders.js
@@ -22,8 +22,7 @@ const teamColors = Array.from({ length: NUM_TEAMS }, (_, i) => {
 const riderGeom = new THREE.BoxGeometry(1.7, 1.5, 0.5);
 
 const RIDER_WIDTH = 1.7; // match geometry width
-// Reduced gap to fit more riders across the road at base speed
-// Slightly smaller gap so more riders fit side by side
+// écart minimal pour éviter les collisions latérales
 const MIN_LATERAL_GAP = 0.2;
 // Collision body dimensions for Cannon.js bodies
 // Swap width/depth so side collisions use the long face of the box
@@ -56,11 +55,12 @@ for (let team = 0; team < NUM_TEAMS; team++) {
     const trackDist0 =
       (TRACK_LENGTH - row * ROW_SPACING + trackJitter + TRACK_WRAP) % TRACK_WRAP;
 
-    const usableWidth = ROAD_WIDTH - RIDER_WIDTH;
+    const halfRider = RIDER_WIDTH / 2;
+    const edgeGap = MIN_LATERAL_GAP / 2;
+    const maxOff = ROAD_WIDTH / 2 - halfRider - edgeGap;
+    const usableWidth = maxOff * 2;
     const rawOff =
       (ridersPerRow === 1 ? 0 : col / (ridersPerRow - 1) - 0.5) * usableWidth;
-    const halfRider = RIDER_WIDTH / 2;
-    const maxOff = ROAD_WIDTH / 2 - halfRider;
     const off = THREE.MathUtils.clamp(
       rawOff + THREE.MathUtils.randFloatSpread(0.3),
       -maxOff,


### PR DESCRIPTION
## Summary
- restore `MIN_LATERAL_GAP` to prevent collision bugs
- spread riders all the way across the road
- update constants accordingly
- bump version to 1.0.15

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687ffb948d308329bbeeb66c49a9576d