### PR TITLE
Add mode toggles for teams and riders

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Cette simulation affiche un peloton de cyclistes en 3D dans votre navigateur. Le
 Ouvrez `index.html` dans un navigateur moderne. Le fichier charge automatiquement les modules nécessaires via des imports ES modules et utilise des bibliothèques depuis un CDN.
 Les versions du projet sont désormais créées automatiquement lors d'un merge dans `main` grâce au workflow `release-please`. Consultez les releases GitHub pour connaître la dernière version disponible.
 
-Chaque coureur dispose maintenant d'un bouton **Attack** qui le pousse à 120 % d'intensité tant que sa jauge d'attaque n'est pas vide. Celle-ci se vide rapidement lors d'une attaque et se recharge lentement ensuite.
+Chaque coureur dispose maintenant d'un interrupteur permettant de choisir entre les modes **Follower**, **Relay** et **Attack**. Le mode Attack pousse le coureur à 120 % d'intensité tant que sa jauge d'attaque n'est pas vide.
+Chaque équipe possède également un interrupteur global pour passer de **Follower** à **Relay**.
 
 ## Gestion des relais
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "",
   "main": "simulation.js",
   "scripts": {

--- a/src/ui.js
+++ b/src/ui.js
@@ -36,20 +36,20 @@ teamColorsCss.forEach((col, t) => {
  */
 function showTeamControls(tid) {
   teamControlsDiv.innerHTML = '';
-  const teamRelayBtn = document.createElement('button');
-  let relayLevel = riders.find(r => r.team === tid)?.relaySetting ?? 0;
-  const updateTeamRelayLabel = () => {
-    teamRelayBtn.textContent = relayLevel > 0 ? `Team Relay ${relayLevel}` : 'Team Relay';
+  const teamModeBtn = document.createElement('button');
+  let teamMode = riders.find(r => r.team === tid && r.relaySetting > 0) ? 'Relay' : 'Follower';
+  const updateTeamModeLabel = () => {
+    teamModeBtn.textContent = teamMode;
   };
-  updateTeamRelayLabel();
-  teamRelayBtn.addEventListener('click', () => {
-    relayLevel = relayLevel % 3 + 1;
+  updateTeamModeLabel();
+  teamModeBtn.addEventListener('click', () => {
+    teamMode = teamMode === 'Relay' ? 'Follower' : 'Relay';
     riders
       .filter(r => r.team === tid)
       .forEach(r => {
-        r.relaySetting = relayLevel;
+        r.relaySetting = teamMode === 'Relay' ? 3 : 0;
       });
-    updateTeamRelayLabel();
+    updateTeamModeLabel();
   });
 
   const intensityLabel = document.createElement('label');
@@ -79,7 +79,7 @@ function showTeamControls(tid) {
   });
   const teamIntensityContainer = document.createElement('div');
   teamIntensityContainer.append(intensityLabel, teamIntInput, teamIntVal);
-  teamControlsDiv.append(teamRelayBtn, teamIntensityContainer, document.createElement('hr'));
+  teamControlsDiv.append(teamModeBtn, teamIntensityContainer, document.createElement('hr'));
   riders
     .filter(r => r.team === tid)
     .forEach((r, idx) => {
@@ -89,8 +89,7 @@ function showTeamControls(tid) {
       <span>Rider ${idx + 1}${r.isLeader ? ' (Leader)' : ''}</span>
       <label>Intensity:<input type="range" min="0" max="100" step="25" list="intensityTicks" id="int_${tid}_${idx}" value="${r.baseIntensity}"/><span id="int_val_${tid}_${idx}">${r.baseIntensity}</span></label>
       <label><input type="checkbox" id="prot_${tid}_${idx}" ${r.protectLeader ? 'checked' : ''} ${r.isLeader ? 'disabled' : ''}/> Protect</label>
-      <button id="relay_btn_${tid}_${idx}">Relay</button>
-      <button id="atk_${tid}_${idx}">Attack</button>
+      <button id="mode_btn_${tid}_${idx}">Follower</button>
       <progress id="gauge_${tid}_${idx}" max="100" value="${r.attackGauge}"></progress>`;
       teamControlsDiv.append(row);
       const intensityInput = document.getElementById(`int_${tid}_${idx}`);
@@ -116,11 +115,33 @@ function showTeamControls(tid) {
         }
       });
       document.getElementById(`prot_${tid}_${idx}`).addEventListener('change', e => (r.protectLeader = e.target.checked));
-      document.getElementById(`relay_btn_${tid}_${idx}`).addEventListener('click', () => {
-        r.relaySetting = r.relaySetting > 0 ? 0 : 3;
-      });
-      document.getElementById(`atk_${tid}_${idx}`).addEventListener('click', () => {
-        if (r.attackGauge > 0) r.isAttacking = true;
+      const modeBtn = document.getElementById(`mode_btn_${tid}_${idx}`);
+      let mode = r.isAttacking ? 'Attack' : r.relaySetting > 0 ? 'Relay' : 'Follower';
+      const updateModeLabel = () => {
+        modeBtn.textContent = mode;
+      };
+      updateModeLabel();
+      modeBtn.addEventListener('click', () => {
+        if (mode === 'Follower') {
+          mode = 'Relay';
+          r.relaySetting = 3;
+          r.isAttacking = false;
+        } else if (mode === 'Relay') {
+          if (r.attackGauge > 0) {
+            mode = 'Attack';
+            r.isAttacking = true;
+            r.relaySetting = 0;
+          } else {
+            mode = 'Follower';
+            r.relaySetting = 0;
+            r.isAttacking = false;
+          }
+        } else {
+          mode = 'Follower';
+          r.relaySetting = 0;
+          r.isAttacking = false;
+        }
+        updateModeLabel();
       });
     });
 }
@@ -204,6 +225,11 @@ setInterval(() => {
     .forEach((r, idx) => {
       const el = document.getElementById(`gauge_${tid}_${idx}`);
       if (el) el.value = r.attackGauge;
+      const btn = document.getElementById(`mode_btn_${tid}_${idx}`);
+      if (btn) {
+        const expected = r.isAttacking ? 'Attack' : r.relaySetting > 0 ? 'Relay' : 'Follower';
+        if (btn.textContent !== expected) btn.textContent = expected;
+      }
     });
 }, 100);
 


### PR DESCRIPTION
## Summary
- add Follower/Relay toggle for team controls
- add Follower/Relay/Attack toggle for each rider
- automatically update rider buttons when state changes
- document new behaviour in README
- bump version to 1.0.28

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6880ede1bae48329bb7a49108727c445