### PR TITLE
Use advanced line classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "description": "",
   "main": "simulation.js",
   "scripts": {

--- a/src/setupScene.js
+++ b/src/setupScene.js
@@ -13,10 +13,20 @@ const dirLight = new THREE.DirectionalLight(0xffffff, 0.8);
 dirLight.position.set(100, 200, 100);
 scene.add(dirLight);
 
+// Stocke les LineMaterials à mettre à jour lors du redimensionnement
+const lineMaterials = [];
+function registerLineMaterial(mat) {
+  lineMaterials.push(mat);
+  mat.resolution.set(window.innerWidth, window.innerHeight);
+}
+
 window.addEventListener('resize', () => {
   camera.aspect = window.innerWidth / window.innerHeight;
   camera.updateProjectionMatrix();
   renderer.setSize(window.innerWidth, window.innerHeight);
+  lineMaterials.forEach(mat =>
+    mat.resolution.set(window.innerWidth, window.innerHeight)
+  );
 });
 
-export { THREE, scene, camera, renderer };
+export { THREE, scene, camera, renderer, registerLineMaterial };

--- a/src/track.js
+++ b/src/track.js
@@ -1,6 +1,9 @@
 // Définit la géométrie de la piste et les courbes auxiliaires
 
-import { THREE, scene } from './setupScene.js';
+import { THREE, scene, registerLineMaterial } from './setupScene.js';
+import { Line2 } from 'https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/lines/Line2.js';
+import { LineGeometry } from 'https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/lines/LineGeometry.js';
+import { LineDashedMaterial } from 'https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/lines/LineDashedMaterial.js';
 
 const TRACK_LENGTH = 1000;
 // Élargit légèrement la route pour que six coureurs puissent passer côte à côte
@@ -31,16 +34,20 @@ for (let a = 0; a < Math.PI * 2; a += STEP_ANGLE) {
 const centerSpline = new THREE.CatmullRomCurve3(trackPoints, true);
 
 // Ligne centrale en pointillés (ligne de dissuasion)
-const centerLineGeometry = new THREE.BufferGeometry().setFromPoints(
-  centerSpline.getPoints(500)
+const centerLineGeometry = new LineGeometry();
+centerLineGeometry.setPositions(
+  centerSpline
+    .getPoints(500)
+    .flatMap(p => [p.x, p.y, p.z])
 );
-const centerLineMaterial = new THREE.LineDashedMaterial({
+const centerLineMaterial = new LineDashedMaterial({
   color: 0xffffff,
   linewidth: 3,
   dashSize: 5,
   gapSize: 3
 });
-const centerLine = new THREE.Line(centerLineGeometry, centerLineMaterial);
+registerLineMaterial(centerLineMaterial);
+const centerLine = new Line2(centerLineGeometry, centerLineMaterial);
 centerLine.computeLineDistances();
 scene.add(centerLine);
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,18 +1,30 @@
 // Interface utilisateur: sélection et contrôles des coureurs
 
-import { THREE, camera, renderer, scene } from './setupScene.js';
+import {
+  THREE,
+  camera,
+  renderer,
+  scene,
+  registerLineMaterial
+} from './setupScene.js';
 import { riders, teamColors, riderGeom } from './riders.js';
 import { TRACK_WRAP } from './track.js';
 import { on, emit } from './eventBus.js';
+import { LineSegments2 } from 'https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/lines/LineSegments2.js';
+import { LineSegmentsGeometry } from 'https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/lines/LineSegmentsGeometry.js';
+import { LineMaterial } from 'https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/lines/LineMaterial.js';
 
 // Au démarrage, on se concentre sur un coureur situé vers le milieu du peloton
 let selectedIndex = Math.floor(riders.length / 2);
 const raycaster = new THREE.Raycaster();
 const mouse = new THREE.Vector2();
 
-const selectionMarkerGeom = new THREE.EdgesGeometry(riderGeom);
-const selectionMarkerMat = new THREE.LineBasicMaterial({ color: 0xffff00, linewidth: 4 });
-const selectionMarker = new THREE.LineSegments(selectionMarkerGeom, selectionMarkerMat);
+const selectionEdges = new THREE.EdgesGeometry(riderGeom);
+const selectionMarkerGeom = new LineSegmentsGeometry().fromEdgesGeometry(selectionEdges);
+const selectionMarkerMat = new LineMaterial({ color: 0xffff00, linewidth: 4 });
+registerLineMaterial(selectionMarkerMat);
+const selectionMarker = new LineSegments2(selectionMarkerGeom, selectionMarkerMat);
+selectionMarker.computeLineDistances();
 selectionMarker.visible = false;
 scene.add(selectionMarker);
 


### PR DESCRIPTION
## Summary
- use `Line2` and related helpers for center dashed line
- update selection marker to use `LineSegments2`
- expose `registerLineMaterial` so materials update on resize
- bump version to 1.0.30

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6880ef68a7548329b04a0ff65161fd4d