### PR TITLE
Fix imports for three.js modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "",
   "main": "simulation.js",
   "scripts": {

--- a/src/track.js
+++ b/src/track.js
@@ -1,9 +1,9 @@
 // Définit la géométrie de la piste et les courbes auxiliaires
 
 import { THREE, scene, registerLineMaterial } from './setupScene.js';
-import { Line2 } from 'https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/lines/Line2.js';
-import { LineGeometry } from 'https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/lines/LineGeometry.js';
-import { LineDashedMaterial } from 'https://cdn.jsdelivr.net/npm/three@0.120.0/src/materials/LineDashedMaterial.js';
+import { Line2 } from 'https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/lines/Line2.js?module';
+import { LineGeometry } from 'https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/lines/LineGeometry.js?module';
+import { LineDashedMaterial } from 'https://cdn.jsdelivr.net/npm/three@0.153.0/src/materials/LineDashedMaterial.js?module';
 
 const TRACK_LENGTH = 1000;
 // Élargit légèrement la route pour que six coureurs puissent passer côte à côte

--- a/src/ui.js
+++ b/src/ui.js
@@ -10,9 +10,9 @@ import {
 import { riders, teamColors, riderGeom } from './riders.js';
 import { TRACK_WRAP } from './track.js';
 import { on, emit } from './eventBus.js';
-import { LineSegments2 } from 'https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/lines/LineSegments2.js';
-import { LineSegmentsGeometry } from 'https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/lines/LineSegmentsGeometry.js';
-import { LineMaterial } from 'https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/lines/LineMaterial.js';
+import { LineSegments2 } from 'https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/lines/LineSegments2.js?module';
+import { LineSegmentsGeometry } from 'https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/lines/LineSegmentsGeometry.js?module';
+import { LineMaterial } from 'https://cdn.jsdelivr.net/npm/three@0.153.0/examples/jsm/lines/LineMaterial.js?module';
 
 // Au démarrage, on se concentre sur un coureur situé vers le milieu du peloton
 let selectedIndex = Math.floor(riders.length / 2);


### PR DESCRIPTION
## Summary
- update three.js example imports to use `?module` parameter
- align LineDashedMaterial version
- bump version to 1.0.32

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6880f453d93c832996d828780b0a23fd