### PR TITLE
Fix line material import and unify Three.js path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.29",
+  "version": "1.0.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.29",
+      "version": "1.0.34",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^9.31.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "",
   "main": "simulation.js",
   "scripts": {

--- a/src/leaderTraceExample.js
+++ b/src/leaderTraceExample.js
@@ -2,7 +2,7 @@
 // Les positions récentes du leader sont stockées dans un buffer circulaire
 // Chaque suiveur vise une ancienne position du leader pour former une file indienne
 
-import * as THREE from 'https://unpkg.com/three@0.153.0/build/three.module.js?module';
+import * as THREE from 'https://unpkg.com/three@0.153.0/build/three.module.js';
 import * as CANNON from 'https://unpkg.com/cannon-es@0.20.0/dist/cannon-es.js?module';
 
 // Paramètres principaux

--- a/src/setupScene.js
+++ b/src/setupScene.js
@@ -1,6 +1,6 @@
 // Prépare la scène Three.js, la caméra et le renderer
 
-import * as THREE from 'https://unpkg.com/three@0.153.0/build/three.module.js?module';
+import * as THREE from 'https://unpkg.com/three@0.153.0/build/three.module.js';
 
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x000000);

--- a/src/track.js
+++ b/src/track.js
@@ -3,7 +3,7 @@
 import { THREE, scene, registerLineMaterial } from './setupScene.js';
 import { Line2 } from 'https://unpkg.com/three@0.153.0/examples/jsm/lines/Line2.js?module';
 import { LineGeometry } from 'https://unpkg.com/three@0.153.0/examples/jsm/lines/LineGeometry.js?module';
-import { LineDashedMaterial } from 'https://unpkg.com/three@0.153.0/src/materials/LineDashedMaterial.js?module';
+import { LineMaterial } from 'https://unpkg.com/three@0.153.0/examples/jsm/lines/LineMaterial.js?module';
 
 const TRACK_LENGTH = 1000;
 // Élargit légèrement la route pour que six coureurs puissent passer côte à côte
@@ -40,9 +40,10 @@ centerLineGeometry.setPositions(
     .getPoints(500)
     .flatMap(p => [p.x, p.y, p.z])
 );
-const centerLineMaterial = new LineDashedMaterial({
+const centerLineMaterial = new LineMaterial({
   color: 0xffffff,
   linewidth: 3,
+  dashed: true,
   dashSize: 5,
   gapSize: 3
 });


### PR DESCRIPTION
## Summary
- load the Three.js module without the `?module` query
- unify the import of Three.js for the example script
- switch the center line to use `LineMaterial` so `resolution` exists
- bump version to 1.0.34

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6880fd887fec8329904ea4a7e9ab81a0