### PR TITLE
Add import map for Three.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,13 @@
     <link rel="icon" type="image/png" href="favicon.png" />
     <title>Peloton Simulation Prototype</title>
     <link rel="stylesheet" href="style.css" />
+    <script type="importmap">
+      {
+        "imports": {
+          "three": "https://unpkg.com/three@0.153.0/build/three.module.js"
+        }
+      }
+    </script>
 </head>
 
 <body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "",
   "main": "simulation.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- ensure a single Three.js instance by adding an import map in `index.html`
- bump version to 1.0.35

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6880ff9cf4948329a15a867fab37b074