### PR TITLE
Fix duplicate Three.js import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.34",
+  "version": "1.0.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.34",
+      "version": "1.0.36",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^9.31.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "",
   "main": "simulation.js",
   "scripts": {

--- a/src/leaderTraceExample.js
+++ b/src/leaderTraceExample.js
@@ -2,7 +2,7 @@
 // Les positions récentes du leader sont stockées dans un buffer circulaire
 // Chaque suiveur vise une ancienne position du leader pour former une file indienne
 
-import * as THREE from 'https://unpkg.com/three@0.153.0/build/three.module.js';
+import * as THREE from 'three';
 import * as CANNON from 'https://unpkg.com/cannon-es@0.20.0/dist/cannon-es.js?module';
 
 // Paramètres principaux

--- a/src/setupScene.js
+++ b/src/setupScene.js
@@ -1,6 +1,6 @@
 // Prépare la scène Three.js, la caméra et le renderer
 
-import * as THREE from 'https://unpkg.com/three@0.153.0/build/three.module.js';
+import * as THREE from 'three';
 
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x000000);


### PR DESCRIPTION
## Summary
- ensure all modules import Three.js via import map
- bump version to 1.0.36

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6881067c5b98832998b77082823a5e9d