### PR TITLE
Centralize relay constants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "description": "",
   "main": "simulation.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -20,6 +20,13 @@ import { updateSelectionHelper, selectedIndex } from '../ui/ui.js';
 import { started } from '../ui/startButton.js';
 import { aheadDistance, wrapDistance } from '../utils/utils.js';
 import { BASE_SPEED, RELAY_MIN_DIST, RELAY_MAX_DIST } from '../utils/constants.js';
+import {
+  BASE_RELAY_INTERVAL,
+  RELAY_JOIN_GAP,
+  PULL_OFF_TIME,
+  PULL_OFFSET,
+  RELAY_TARGET_GAP
+} from '../utils/relayConstants.js';
 import { updateRelayCluster } from './relayCluster.js';
 import { relayStep } from './relayLogic.js';
 import { emit } from '../utils/eventBus.js';
@@ -37,17 +44,12 @@ const MAX_LATERAL_SPEED = 3;
 const MAX_LANE_OFFSET = ROAD_WIDTH / 2 - RIDER_WIDTH / 2 - MIN_LATERAL_GAP / 2;
 // Ralentit les changements de ligne pour des dépassements plus fluides
 const LANE_CHANGE_SPEED = 1.5;
-const BASE_RELAY_INTERVAL = 5;
-const RELAY_JOIN_GAP = 10;
-const PULL_OFF_TIME = 2;
-const PULL_OFFSET = 1.5;
 const PULL_OFF_SPEED_FACTOR = 0.7;
 const ATTACK_INTENSITY = 60; // 120 % de l'intensité de base
 const ATTACK_DRAIN = 50; // unités de jauge par seconde lors d'une attaque
 const ATTACK_RECOVERY = 10; // récupération de jauge par seconde
 const RELAY_QUEUE_GAP = 2.5;
 const RELAY_CHASE_INTENSITY = 70;
-const RELAY_TARGET_GAP = 1.5;
 const RELAY_LEADER_INTENSITY = 70;
 // Force appliquée pour corriger l'écart entre deux coureurs en relais
 const RELAY_CORRECTION_GAIN = 5;

--- a/src/logic/relayLogic.js
+++ b/src/logic/relayLogic.js
@@ -1,12 +1,13 @@
 import { RELAY_MIN_DIST, RELAY_MAX_DIST } from '../utils/constants.js';
 import { emit } from '../utils/eventBus.js';
-
-const BASE_RELAY_INTERVAL = 5;
-const RELAY_JOIN_GAP = 10;
-const PULL_OFF_TIME = 2;
-const PULL_OFFSET = 1.5;
-const RELAY_TARGET_GAP = 1.5;
-const TRACK_WRAP = 1000;
+import {
+  BASE_RELAY_INTERVAL,
+  RELAY_JOIN_GAP,
+  PULL_OFF_TIME,
+  PULL_OFFSET,
+  RELAY_TARGET_GAP
+} from '../utils/relayConstants.js';
+import { aheadDistance } from '../utils/utils.js';
 
 function setPhase(rider, phase) {
   if (rider.relayPhase !== phase) {
@@ -18,11 +19,6 @@ function setPhase(rider, phase) {
   }
 }
 
-function aheadDistance(from, to) {
-  let diff = (to - from) % TRACK_WRAP;
-  if (diff < 0) diff += TRACK_WRAP;
-  return diff;
-}
 
 function relayStep(riders, state, dt) {
   const sorted = riders

--- a/src/utils/relayConstants.js
+++ b/src/utils/relayConstants.js
@@ -1,0 +1,15 @@
+// Constantes spécifiques au fonctionnement du relais
+
+const BASE_RELAY_INTERVAL = 5;
+const RELAY_JOIN_GAP = 10;
+const PULL_OFF_TIME = 2;
+const PULL_OFFSET = 1.5;
+const RELAY_TARGET_GAP = 1.5;
+
+export {
+  BASE_RELAY_INTERVAL,
+  RELAY_JOIN_GAP,
+  PULL_OFF_TIME,
+  PULL_OFFSET,
+  RELAY_TARGET_GAP
+};

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,6 +1,8 @@
 // Fonctions utilitaires pour calculer les distances sur la piste
 
-import { TRACK_WRAP } from '../entities/track.js';
+// Valeur du tour de piste. Importer directement la piste impliquerait la
+// configuration de Three.js, ce qui complique l'exécution des tests Node.
+const TRACK_WRAP = 1000;
 
 /**
  * Convertit des coordonnées polaires en distance le long de la piste.


### PR DESCRIPTION
## Summary
- centralize relay constants in new module `relayConstants.js`
- share `aheadDistance` utility across modules
- update imports in animation and relay logic
- bump version to 1.0.41
- tests adjusted for new imports

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68813143d10c83298b7918cbe44f5fc1