### PR TITLE
fix: use correct entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "la_bonne_echappee",
   "version": "1.0.42",
   "description": "",
-  "main": "simulation.js",
+  "main": "src/core/main.js",
   "scripts": {
     "test": "node test/relayCluster.test.js && node test/relayCycle.test.js && node test/eventBus.test.js && node test/overlapResolution.test.js",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary
- fix `main` field in package.json to point at `src/core/main.js`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6881e3b034e08329a8b04e07198517a4