### PR TITLE
Improve center line perspective rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "description": "",
   "main": "simulation.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- render dashed center line using small white planes instead of Line2
- bump version to 1.0.43

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6881e429b9d08329995c3fdfaff9a5c8