### PR TITLE
Add mouse-controlled camera rotation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "description": "",
   "main": "simulation.js",
   "scripts": {

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -8,6 +8,8 @@ import '../ui/ui.js';
 import '../ui/startButton.js';
 import initVersion from '../utils/version.js';
 import { animate } from '../logic/animation.js';
+import { initCameraControls } from '../logic/cameraController.js';
 
+initCameraControls();
 animate();
 initVersion();


### PR DESCRIPTION
## Summary
- enable camera rotation with middle-mouse drag
- reset camera on middle-mouse double click
- init camera controls in main entry
- bump version to 1.0.43

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6881e49e27f083298328d2b590a13e7e