### PR TITLE
Add ambient sound based on camera zoom

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/ambientSound.js
+++ b/src/logic/ambientSound.js
@@ -1,0 +1,35 @@
+const applause = new Audio('sounds/applause-01.wav');
+const helicopter = new Audio('sounds/helicopter.wav');
+
+applause.loop = true;
+helicopter.loop = true;
+
+/**
+ * Met à jour le volume des sons d'ambiance en fonction du niveau de zoom.
+ *
+ * @param {number} progress Valeur comprise entre 0 (zoom le plus proche)
+ * et 1 (zoom le plus lointain).
+ * @returns {void}
+ */
+function updateAmbientSound(progress) {
+  const t = Math.min(1, Math.max(0, progress));
+  applause.volume = 1 - 0.9 * t;
+  helicopter.volume = 0.1 + 0.9 * t;
+}
+
+/**
+ * Initialise la lecture des effets sonores d'ambiance.
+ *
+ * @param {number} progress Niveau de zoom initial normalisé.
+ * @returns {void}
+ */
+function initAmbientSound(progress = 0) {
+  // Les volumes sont mis à zéro pour tenter la lecture sans interaction.
+  applause.volume = 0;
+  helicopter.volume = 0;
+  applause.play().catch(() => {});
+  helicopter.play().catch(() => {});
+  updateAmbientSound(progress);
+}
+
+export { initAmbientSound, updateAmbientSound };

--- a/src/logic/cameraController.js
+++ b/src/logic/cameraController.js
@@ -2,6 +2,7 @@ import { THREE, camera, renderer } from '../core/setupScene.js';
 import { riders } from '../entities/riders.js';
 import { TRACK_WRAP } from '../entities/track.js';
 import { selectedIndex } from '../ui/ui.js';
+import { initAmbientSound, updateAmbientSound } from './ambientSound.js';
 
 const forwardVec = new THREE.Vector3();
 const lookAtPt = new THREE.Vector3();
@@ -21,6 +22,7 @@ function initCameraControls() {
     if (e.detail === 2) {
       extraAngle = 0;
       zoomFactor = 1;
+      updateAmbientSound((zoomFactor - MIN_ZOOM) / (MAX_ZOOM - MIN_ZOOM));
       return;
     }
     rotating = true;
@@ -42,8 +44,11 @@ function initCameraControls() {
   renderer.domElement.addEventListener('wheel', e => {
     const delta = e.deltaY > 0 ? 0.1 : -0.1;
     zoomFactor = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoomFactor + delta));
+    updateAmbientSound((zoomFactor - MIN_ZOOM) / (MAX_ZOOM - MIN_ZOOM));
     e.preventDefault();
   });
+
+  initAmbientSound((zoomFactor - MIN_ZOOM) / (MAX_ZOOM - MIN_ZOOM));
 }
 
 function updateCamera() {


### PR DESCRIPTION
## Summary
- play applause and helicopter sounds continuously
- control volume according to camera zoom
- init sounds with camera controller
- bump version to 1.0.46

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6881ed7ef66c8329aaee6174745e8ab6