### PR TITLE
Fix start intensity bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -335,10 +335,10 @@ function animate() {
       } else {
         r.attackGauge = Math.min(100, r.attackGauge + ATTACK_RECOVERY * dt);
         let newInt = r.baseIntensity;
-        if (r.relayChasing) {
+        if (r.relayChasing && r.baseIntensity >= RELAY_CHASE_INTENSITY) {
           newInt = Math.max(newInt, RELAY_CHASE_INTENSITY);
         }
-        if (r.relayLeader) {
+        if (r.relayLeader && r.baseIntensity >= RELAY_LEADER_INTENSITY) {
           newInt = Math.max(newInt, RELAY_LEADER_INTENSITY);
         }
         setIntensity(r, newInt);


### PR DESCRIPTION
## Summary
- prevent relay chasing from overriding base intensity when it's lower than chase threshold
- bump version to 1.0.47

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6881eeed99208329bd58eaef16029db6