### PR TITLE
Add sound toggle and resume audio on start

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
     </div>
 
     <button id="startBtn" style="position: absolute; bottom: 10px; right: 10px; padding: 8px 12px; z-index: 100;">Start</button>
+    <button id="soundToggle" style="position: absolute; bottom: 10px; right: 70px; padding: 8px 12px; z-index: 100;">🔊</button>
 
     <div id="vis"></div>
     <div id="version-container"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -6,6 +6,7 @@ import '../entities/track.js';
 import '../entities/riders.js';
 import '../ui/ui.js';
 import '../ui/startButton.js';
+import '../ui/soundToggle.js';
 import initVersion from '../utils/version.js';
 import { animate } from '../logic/animation.js';
 import { initCameraControls } from '../logic/cameraController.js';

--- a/src/logic/ambientSound.js
+++ b/src/logic/ambientSound.js
@@ -32,4 +32,29 @@ function initAmbientSound(progress = 0) {
   updateAmbientSound(progress);
 }
 
-export { initAmbientSound, updateAmbientSound };
+/**
+ * Relance la lecture des sons d'ambiance suite à une interaction utilisateur.
+ *
+ * @returns {void}
+ */
+function resumeAmbientSound() {
+  applause.play().catch(() => {});
+  helicopter.play().catch(() => {});
+}
+
+/**
+ * Met la lecture des sons d'ambiance en pause.
+ *
+ * @returns {void}
+ */
+function pauseAmbientSound() {
+  applause.pause();
+  helicopter.pause();
+}
+
+export {
+  initAmbientSound,
+  updateAmbientSound,
+  resumeAmbientSound,
+  pauseAmbientSound
+};

--- a/src/ui/soundToggle.js
+++ b/src/ui/soundToggle.js
@@ -1,0 +1,19 @@
+import { resumeAmbientSound, pauseAmbientSound } from '../logic/ambientSound.js';
+
+const toggleBtn = document.getElementById('soundToggle');
+let enabled = true;
+
+if (toggleBtn) {
+  toggleBtn.addEventListener('click', () => {
+    enabled = !enabled;
+    if (enabled) {
+      toggleBtn.textContent = '🔊';
+      resumeAmbientSound();
+    } else {
+      toggleBtn.textContent = '🔇';
+      pauseAmbientSound();
+    }
+  });
+}
+
+export { enabled as soundEnabled };

--- a/src/ui/startButton.js
+++ b/src/ui/startButton.js
@@ -4,6 +4,7 @@ import { riders } from '../entities/riders.js';
 import { polarToDist } from '../utils/utils.js';
 import { BASE_SPEED } from '../utils/constants.js';
 import { emit } from '../utils/eventBus.js';
+import { resumeAmbientSound } from '../logic/ambientSound.js';
 
 let started = false;
 
@@ -11,6 +12,7 @@ const startBtn = document.getElementById('startBtn');
 if (startBtn) {
   startBtn.addEventListener('click', () => {
     started = true;
+    resumeAmbientSound();
     riders.forEach(r => {
       r.currentBoost = 0;
       r.isAttacking = false;

--- a/style.css
+++ b/style.css
@@ -76,3 +76,10 @@ input[type='range'] {
     font-size: 0.9em;
     color: #fff;
 }
+
+#soundToggle {
+    background: rgba(20, 20, 20, 0.8);
+    border: none;
+    color: #fff;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add new sound toggle button to UI
- allow resuming ambient sound on start
- implement sound enable/disable logic
- expose sound toggle module from main
- bump version to 1.0.48

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6881f012f91883299a4b626652e3401d