### PR TITLE
Implement rider energy mechanics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/entities/riders.js
+++ b/src/entities/riders.js
@@ -106,6 +106,7 @@ for (let team = 0; team < NUM_TEAMS; team++) {
       relayIntensity: 0,
       baseIntensity: 50,
       intensity: 50,
+      energy: 100,
       relayChasing: false,
       relayLeader: false,
       inRelayLine: false,

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -20,6 +20,7 @@ import { updateSelectionHelper, selectedIndex } from '../ui/ui.js';
 import { started } from '../ui/startButton.js';
 import { aheadDistance, wrapDistance } from '../utils/utils.js';
 import { BASE_SPEED } from '../utils/constants.js';
+import { updateEnergy } from './energyLogic.js';
 import { updateRelays } from './relayController.js';
 import { updateCamera } from './cameraController.js';
 import { emit } from '../utils/eventBus.js';
@@ -376,6 +377,7 @@ function animate() {
     limitLateralSpeed();
     updatePelotonChase();
     updateDraftFactors();
+    updateEnergy(riders, dt);
 
     riders.forEach(r => {
       if (r.isAttacking) {

--- a/src/logic/energyLogic.js
+++ b/src/logic/energyLogic.js
@@ -1,0 +1,14 @@
+import { FATIGUE_RATE, RECOVERY_RATE } from '../utils/constants.js';
+
+function updateEnergy(riders, dt) {
+  riders.forEach(r => {
+    if (r.relayPhase === 'pull') {
+      r.energy = Math.max(0, r.energy - FATIGUE_RATE * dt);
+    } else if (r.draftFactor > 1 || r.inRelayLine) {
+      r.energy = Math.min(100, r.energy + RECOVERY_RATE * dt);
+    }
+  });
+}
+
+export { updateEnergy };
+

--- a/src/logic/relayLogic.js
+++ b/src/logic/relayLogic.js
@@ -1,4 +1,8 @@
-import { RELAY_MIN_DIST, RELAY_MAX_DIST } from '../utils/constants.js';
+import {
+  RELAY_MIN_DIST,
+  RELAY_MAX_DIST,
+  ENERGY_THRESHOLD
+} from '../utils/constants.js';
 import { emit } from '../utils/eventBus.js';
 import {
   BASE_RELAY_INTERVAL,
@@ -49,7 +53,13 @@ function relayStep(riders, state, dt) {
   }
 
   if (state.index >= queue.length) state.index = 0;
-  const leader = queue[state.index];
+  let leader = queue[state.index];
+  let attempts = 0;
+  while (leader.energy < ENERGY_THRESHOLD && attempts < queue.length) {
+    state.index = (state.index + 1) % queue.length;
+    leader = queue[state.index];
+    attempts += 1;
+  }
 
   riders.forEach(r => {
     r.relayIntensity = 0;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -4,4 +4,16 @@ const BASE_SPEED = 8;
 const RELAY_MIN_DIST = 1.0;
 const RELAY_MAX_DIST = 3.0;
 
-export { BASE_SPEED, RELAY_MIN_DIST, RELAY_MAX_DIST };
+// Gestion de la fatigue et de la récupération d'énergie
+const FATIGUE_RATE = 5; // unités par seconde
+const RECOVERY_RATE = 3; // unités par seconde
+const ENERGY_THRESHOLD = 20;
+
+export {
+  BASE_SPEED,
+  RELAY_MIN_DIST,
+  RELAY_MAX_DIST,
+  FATIGUE_RATE,
+  RECOVERY_RATE,
+  ENERGY_THRESHOLD
+};

--- a/test/energy.test.js
+++ b/test/energy.test.js
@@ -1,0 +1,19 @@
+import assert from 'node:assert';
+import { updateEnergy } from '../src/logic/energyLogic.js';
+import { FATIGUE_RATE, RECOVERY_RATE } from '../src/utils/constants.js';
+
+function testFatigue() {
+  const riders = [{ relayPhase: 'pull', draftFactor: 1, inRelayLine: false, energy: 100 }];
+  updateEnergy(riders, 1);
+  assert.strictEqual(riders[0].energy, 100 - FATIGUE_RATE);
+}
+
+function testRecovery() {
+  const riders = [{ relayPhase: 'line', draftFactor: 1.2, inRelayLine: false, energy: 50 }];
+  updateEnergy(riders, 1);
+  assert.strictEqual(riders[0].energy, 50 + RECOVERY_RATE);
+}
+
+testFatigue();
+testRecovery();
+console.log('Energy tests executed');


### PR DESCRIPTION
## Summary
- give riders an energy stat
- define fatigue and recovery constants
- update energy each animation frame
- ignore tired riders in relay logic
- add energy unit tests
- bump version to 1.0.50

## Testing
- `npm run lint`
- `npm test`
- `node test/energy.test.js`


------
https://chatgpt.com/codex/tasks/task_b_6882288306d88329b923c3a440c02874