### PR TITLE
Add protected leader behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.52",
+  "version": "1.0.53",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {
-    "test": "node test/relayCluster.test.js && node test/relayCycle.test.js && node test/eventBus.test.js && node test/overlapResolution.test.js && node test/dashOrientation.test.js && node test/draftFactor.test.js",
+    "test": "node test/relayCluster.test.js && node test/relayCycle.test.js && node test/eventBus.test.js && node test/overlapResolution.test.js && node test/dashOrientation.test.js && node test/draftFactor.test.js && node test/protectLeader.test.js",
     "lint": "eslint .",
     "version": "echo version script removed"
   },

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -169,6 +169,12 @@ function updateLaneOffsets(dt) {
       r.laneOffset = THREE.MathUtils.lerp(r.laneOffset, r.laneTarget, dt);
       return;
     }
+    if (r.protectLeader) {
+      const leader = riders.find(o => o.team === r.team && o.isLeader);
+      if (leader && leader !== r) {
+        r.laneTarget = THREE.MathUtils.lerp(r.laneTarget, leader.laneOffset, dt);
+      }
+    }
     let bestDelta = TRACK_WRAP;
     let ahead = null;
     riders.forEach((o, j) => {
@@ -444,4 +450,4 @@ function animate() {
   renderer.render(scene, camera);
 }
 
-export { animate };
+export { animate, updateLaneOffsets };

--- a/src/logic/draftLogic.js
+++ b/src/logic/draftLogic.js
@@ -37,6 +37,13 @@ function updateDraftFactors(riders, windDirection = 1) {
 
     r.body.linearDamping = 0.2 * drag;
     r.draftFactor = 1 + 0.625 * (1 - drag);
+
+    if (
+      r.isLeader &&
+      riders.some(o => o.team === r.team && o.protectLeader)
+    ) {
+      r.draftFactor += 0.05;
+    }
   });
 }
 

--- a/src/logic/relayLogic.js
+++ b/src/logic/relayLogic.js
@@ -55,7 +55,11 @@ function relayStep(riders, state, dt) {
   if (state.index >= queue.length) state.index = 0;
   let leader = queue[state.index];
   let attempts = 0;
-  while (leader.energy < ENERGY_THRESHOLD && attempts < queue.length) {
+  while (
+    (leader.energy < ENERGY_THRESHOLD ||
+      (leader.isLeader && riders.some(o => o.team === leader.team && o.protectLeader))) &&
+    attempts < queue.length
+  ) {
     state.index = (state.index + 1) % queue.length;
     leader = queue[state.index];
     attempts += 1;

--- a/test/protectLeader.test.js
+++ b/test/protectLeader.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert';
+import { relayStep } from '../src/logic/relayLogic.js';
+
+function protectLeaderTest() {
+  const riders = [
+    {
+      team: 0,
+      isLeader: true,
+      relaySetting: 3,
+      trackDist: 100,
+      baseLaneOffset: 0,
+      laneOffset: 0,
+      laneTarget: 0,
+      relayPhase: 'line',
+      relayTimer: 0,
+      relayTime: 0,
+      energy: 100
+    },
+    {
+      team: 0,
+      protectLeader: true,
+      relaySetting: 3,
+      trackDist: 99,
+      baseLaneOffset: 0,
+      laneOffset: 0,
+      laneTarget: 0,
+      relayPhase: 'line',
+      relayTimer: 0,
+      relayTime: 0,
+      energy: 100
+    },
+    {
+      team: 0,
+      relaySetting: 3,
+      trackDist: 98,
+      baseLaneOffset: 0,
+      laneOffset: 0,
+      laneTarget: 0,
+      relayPhase: 'line',
+      relayTimer: 0,
+      relayTime: 0,
+      energy: 100
+    }
+  ];
+  const state = { index: 0, timer: 0, side: 1 };
+  const res = relayStep(riders, state, 0);
+  assert.notStrictEqual(res.leader, riders[0]);
+  assert.ok(res.leader === riders[1] || res.leader === riders[2]);
+}
+
+protectLeaderTest();
+console.log('Protect leader test executed');


### PR DESCRIPTION
## Summary
- bias lane changes toward team leader when `protectLeader` is enabled
- boost drafting for protected leaders
- skip protected leaders when selecting relay pulls
- export `updateLaneOffsets` for testability
- add regression test for protected leaders
- bump version to 1.0.53

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68822e9920f48329a811ad8bca54a75b