### PR TITLE
Remove breakaway indicator from speed display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.58",
+  "version": "1.0.59",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -295,9 +295,7 @@ setInterval(() => {
     if (selectedIndex !== null) {
       const v = riders[selectedIndex].body.velocity.length();
       const kmh = v * 3.6;
-      let text = `Speed: ${kmh.toFixed(1)} km/h`;
-      const bText = breakawayText();
-      if (bText) text += ` | ${bText}`;
+      const text = `Speed: ${kmh.toFixed(1)} km/h`;
       speedIndicator.textContent = text;
     } else {
       speedIndicator.textContent = '';


### PR DESCRIPTION
## Summary
- remove breakaway info from the speed indicator at the top
- bump version to 1.0.59

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68833b02ab748329b2c3176362066e98