### PR TITLE
Implement team and rider mode selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.61",
+  "version": "1.0.62",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- add mode selector for teams and riders with follower, solo or relay choices
- sync team intensity with riders in relay mode
- disable rider intensity slider based on mode
- bump version to 1.0.62

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68833fff5a8883299115e0bae594c510