### PR TITLE
Remove early attack and chase features

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.62",
+  "version": "1.0.63",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -16,7 +16,7 @@ import {
   ROAD_WIDTH
 } from '../entities/track.js';
 import { stepPhysics } from '../core/physicsWorld.js';
-import { updateSelectionHelper, selectedIndex, chaseTeams } from '../ui/ui.js';
+import { updateSelectionHelper, selectedIndex } from '../ui/ui.js';
 import { started } from '../ui/startButton.js';
 import { aheadDistance, wrapDistance } from '../utils/utils.js';
 import { updateDraftFactors as computeDraftFactors } from './draftLogic.js';
@@ -128,7 +128,7 @@ function updatePelotonChase() {
 
   riders.forEach(r => {
     if (r.mode !== 'solo') {
-      r.relayChasing = chase || chaseTeams.has(r.team);
+      r.relayChasing = chase;
     } else {
       r.relayChasing = false;
     }

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -32,7 +32,6 @@ scene.add(selectionMarker);
 const teamSelect = document.getElementById('teamSelect');
 const teamControlsDiv = document.getElementById('teamControls');
 const speedIndicator = document.getElementById('speed-indicator');
-const chaseTeams = new Set();
 const teamColorsCss = teamColors.map(c => `#${c.getHexString()}`);
 teamColorsCss.forEach((col, t) => {
   const opt = teamSelect.options[t];
@@ -146,22 +145,9 @@ function showTeamControls(tid) {
     if (!relay) resetTeamIntensity();
   });
 
-  const chaseBtn = document.createElement('button');
-  chaseBtn.textContent = chaseTeams.has(tid) ? 'Stop Chase' : 'Chase Breakaway';
-  chaseBtn.addEventListener('click', () => {
-    if (chaseTeams.has(tid)) {
-      chaseTeams.delete(tid);
-      chaseBtn.textContent = 'Chase Breakaway';
-    } else {
-      chaseTeams.add(tid);
-      chaseBtn.textContent = 'Stop Chase';
-    }
-  });
-
   teamControlsDiv.append(
     relayContainer,
     teamIntensityContainer,
-    chaseBtn,
     document.createElement('hr')
   );
   riders
@@ -179,7 +165,6 @@ function showTeamControls(tid) {
         <option value="relay">Relay</option>
       </select>
       <button id="atk_${tid}_${idx}">Attack</button>
-      <button id="early_${tid}_${idx}">Early Atk</button>
       <progress id="gauge_${tid}_${idx}" max="100" value="${r.attackGauge}"></progress>`;
       teamControlsDiv.append(row);
       const intensityInput = document.getElementById(`int_${tid}_${idx}`);
@@ -231,12 +216,6 @@ function showTeamControls(tid) {
       });
       document.getElementById(`atk_${tid}_${idx}`).addEventListener('click', () => {
         if (r.attackGauge > 0) r.isAttacking = true;
-      });
-      document.getElementById(`early_${tid}_${idx}`).addEventListener('click', () => {
-        if (r.attackGauge > 0) {
-          r.isAttacking = true;
-          r.relaySetting = 0;
-        }
       });
     });
 }
@@ -340,4 +319,4 @@ setInterval(() => {
 // S'assurer que le marqueur de sélection est visible au chargement
 updateSelectionHelper();
 
-export { selectedIndex, updateSelectionHelper, chaseTeams };
+export { selectedIndex, updateSelectionHelper };


### PR DESCRIPTION
## Summary
- remove Chase Breakaway button and early attack control
- drop `chaseTeams` logic and simplify peloton chase
- bump version to 1.0.63

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688341549f0c8329bbcc4ab0fc917c8f