### PR TITLE
Add front rider speed handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.63",
+  "version": "1.0.64",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -252,6 +252,20 @@ function updateRiderIntensity(r, dt) {
     return;
   }
 
+  if (r.mode === 'follower') {
+    let minDist = TRACK_WRAP;
+    riders.forEach(o => {
+      if (o === r) return;
+      const d = aheadDistance(r.trackDist, o.trackDist);
+      if (d > 0 && d < minDist) minDist = d;
+    });
+    if (minDist > 2) {
+      const desiredIntensity = Math.min(100, (35 / 3.6 / BASE_SPEED) * 50);
+      setIntensity(r, desiredIntensity);
+      return;
+    }
+  }
+
   if (r.mode === 'relay' && r.relayPhase === 'pull') {
     setIntensity(r, r.relaySetting);
     return;


### PR DESCRIPTION
## Summary
- ensure front riders in follower mode maintain 35 km/h on flat
- bump version to 1.0.64

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688343b4e2f8832982a6ff704d101d75