### PR TITLE
Fix rapier import

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Dans le navigateur, Rapier peut être chargé depuis un CDN avec :
 
 ```html
 <script type="module">
-  import RAPIER from 'https://cdn.jsdelivr.net/npm/@dimforge/rapier3d@0.18.0/rapier.js';
+  import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat';
+  await RAPIER.init();
 </script>
 ```
 

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
         "imports": {
           "three": "https://unpkg.com/three@0.153.0/build/three.module.js",
           "three/addons/": "https://unpkg.com/three@0.153.0/examples/jsm/",
-          "@dimforge/rapier3d": "https://cdn.jsdelivr.net/npm/@dimforge/rapier3d@0.18.0/rapier.js",
-          "@dimforge/rapier3d/rapier.js": "https://cdn.jsdelivr.net/npm/@dimforge/rapier3d@0.18.0/rapier.js"
+          "@dimforge/rapier3d": "https://cdn.skypack.dev/@dimforge/rapier3d-compat",
+          "@dimforge/rapier3d/rapier.js": "https://cdn.skypack.dev/@dimforge/rapier3d-compat"
         }
       }
     </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.68",
+  "version": "1.0.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.68",
+      "version": "1.0.69",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.68",
+  "version": "1.0.69",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/core/physicsWorld.js
+++ b/src/core/physicsWorld.js
@@ -1,6 +1,6 @@
 // Initialise le monde physique Rapier et gère le pas de simulation
 
-import RAPIER from '@dimforge/rapier3d/rapier.js';
+import RAPIER from '@dimforge/rapier3d';
 
 await RAPIER.init();
 

--- a/src/logic/leaderTraceExample.js
+++ b/src/logic/leaderTraceExample.js
@@ -3,7 +3,7 @@
 // Chaque suiveur vise une ancienne position du leader pour former une file indienne
 
 import * as THREE from 'three';
-import RAPIER from '@dimforge/rapier3d/rapier.js';
+import RAPIER from '@dimforge/rapier3d';
 
 await RAPIER.init();
 


### PR DESCRIPTION
## Summary
- use rapier3d-compat from skypack
- update README to show compat version
- update physics imports
- bump version to 1.0.69

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6885de60a90c8329a6d214fddd7abe6d