### PR TITLE
Replace Skypack CDN with unpkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Dans le navigateur, Rapier peut être chargé depuis un CDN avec :
 
 ```html
 <script type="module">
-  import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat';
+  import RAPIER from 'https://unpkg.com/@dimforge/rapier3d-compat@0.18.0/rapier.mjs?module';
   await RAPIER.init();
 </script>
 ```

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
         "imports": {
           "three": "https://unpkg.com/three@0.153.0/build/three.module.js",
           "three/addons/": "https://unpkg.com/three@0.153.0/examples/jsm/",
-          "@dimforge/rapier3d": "https://cdn.skypack.dev/@dimforge/rapier3d-compat",
-          "@dimforge/rapier3d/rapier.js": "https://cdn.skypack.dev/@dimforge/rapier3d-compat"
+          "@dimforge/rapier3d": "https://unpkg.com/@dimforge/rapier3d-compat@0.18.0/rapier.mjs?module",
+          "@dimforge/rapier3d/rapier.js": "https://unpkg.com/@dimforge/rapier3d-compat@0.18.0/rapier.mjs?module"
         }
       }
     </script>


### PR DESCRIPTION
## Summary
- switch rapier3d import in README to `unpkg`
- update importmap in `index.html` to use `unpkg`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6886069998888329ba1c54b49c2da035