### PR TITLE
Fix speed indicator crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.69",
+      "version": "1.0.70",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/core/physicsWorld.js
+++ b/src/core/physicsWorld.js
@@ -2,7 +2,7 @@
 
 import RAPIER from '@dimforge/rapier3d';
 
-await RAPIER.init();
+await RAPIER.init({});
 
 const world = new RAPIER.World({ gravity: { x: 0, y: 0, z: 0 } });
 // Augmente le nombre d'itérations du solveur pour mieux gérer les collisions dans un peloton dense

--- a/src/logic/leaderTraceExample.js
+++ b/src/logic/leaderTraceExample.js
@@ -5,7 +5,7 @@
 import * as THREE from 'three';
 import RAPIER from '@dimforge/rapier3d';
 
-await RAPIER.init();
+await RAPIER.init({});
 
 // Paramètres principaux
 const NUM_RUNNERS = 5; // leader compris

--- a/src/ui/startButton.js
+++ b/src/ui/startButton.js
@@ -5,6 +5,7 @@ import { polarToDist } from '../utils/utils.js';
 import { BASE_SPEED } from '../utils/constants.js';
 import { emit } from '../utils/eventBus.js';
 import { resumeAmbientSound } from '../logic/ambientSound.js';
+import { RAPIER } from '../core/physicsWorld.js';
 
 let started = false;
 
@@ -19,18 +20,17 @@ if (startBtn) {
       r.attackGauge = 100;
       r.intensity = r.baseIntensity;
       emit('intensityChange', { rider: r, value: r.intensity });
-      const angle = Math.atan2(r.body.position.z, r.body.position.x);
+      const pos = r.body.translation();
       // Laisse la physique accélérer progressivement
-      r.body.velocity.set(0, 0, 0);
-      r.body.angularVelocity.set(0, 0, 0);
-      r.body.force.set(0, 0, 0);
-      r.body.torque.set(0, 0, 0);
-      r.mesh.position.copy(r.body.position);
-      r.trackDist = polarToDist(r.body.position.x, r.body.position.z);
+      r.body.setLinvel(new RAPIER.Vector3(0, 0, 0), true);
+      r.body.setAngvel({ x: 0, y: 0, z: 0 }, true);
+      r.body.resetForces();
+      r.mesh.position.copy(pos);
+      r.trackDist = polarToDist(pos.x, pos.z);
       r.prevDist = r.trackDist;
       r.lap = 0;
       if (r.boid) {
-        r.boid.position = [r.body.position.x, r.body.position.z];
+        r.boid.position = [pos.x, pos.z];
         // La vitesse du boid est nulle pour démarrer à l'arrêt
         r.boid.velocity = [0, 0];
       }

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -306,8 +306,9 @@ setInterval(() => {
 setInterval(() => {
   if (speedIndicator) {
     if (selectedIndex !== null) {
-      const v = riders[selectedIndex].body.velocity.length();
-      const kmh = v * 3.6;
+      const vel = riders[selectedIndex].body.linvel();
+      const speed = Math.hypot(vel.x, vel.y, vel.z);
+      const kmh = speed * 3.6;
       const text = `Speed: ${kmh.toFixed(1)} km/h`;
       speedIndicator.textContent = text;
     } else {


### PR DESCRIPTION
## Summary
- fix velocity call in UI to use `linvel`
- correct start button to reset velocities using Rapier
- adapt Rapier initialization syntax
- bump version to 1.0.70

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688608022de48329b13030659b6eab54