### PR TITLE
Fix Rapier initialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.70",
+      "version": "1.0.71",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/core/physicsWorld.js
+++ b/src/core/physicsWorld.js
@@ -2,7 +2,7 @@
 
 import RAPIER from '@dimforge/rapier3d';
 
-await RAPIER.init({});
+await RAPIER.init();
 
 const world = new RAPIER.World({ gravity: { x: 0, y: 0, z: 0 } });
 // Augmente le nombre d'itérations du solveur pour mieux gérer les collisions dans un peloton dense
@@ -11,6 +11,7 @@ world.integrationParameters.numAdditionalFrictionIterations = 40;
 
 let physicsAccumulator = 0;
 const fixedTimeStep = 1 / 60;
+world.timestep = fixedTimeStep;
 /**
  * Avance la simulation physique par pas fixes.
  *
@@ -20,7 +21,7 @@ const fixedTimeStep = 1 / 60;
 function stepPhysics(dt) {
   physicsAccumulator += dt;
   while (physicsAccumulator >= fixedTimeStep) {
-    world.step(fixedTimeStep);
+    world.step();
     physicsAccumulator -= fixedTimeStep;
   }
 }

--- a/src/logic/leaderTraceExample.js
+++ b/src/logic/leaderTraceExample.js
@@ -5,7 +5,7 @@
 import * as THREE from 'three';
 import RAPIER from '@dimforge/rapier3d';
 
-await RAPIER.init({});
+await RAPIER.init();
 
 // Paramètres principaux
 const NUM_RUNNERS = 5; // leader compris


### PR DESCRIPTION
## Summary
- initialize Rapier without deprecated parameters
- set world timestep and call step without dt
- increment package version

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688609d6cf588329827bcd5a29d6d811