### PR TITLE
Fix NaN check in animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.71",
+  "version": "1.0.72",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -502,7 +502,8 @@ function animate() {
     if (distRaw < r.prevDist - TRACK_WRAP / 2) r.lap += 1;
     r.prevDist = distRaw;
     r.trackDist = distRaw + r.lap * TRACK_WRAP;
-    const u = (distRaw % TRACK_WRAP) / TRACK_WRAP;
+    const uRaw = (distRaw % TRACK_WRAP) / TRACK_WRAP;
+    const u = Number.isFinite(uRaw) ? uRaw : 0;
     const posOut = outerSpline.getPointAt(u);
     const posIn = innerSpline.getPointAt(u);
     const t0 = centerSpline.getTangentAt(u);


### PR DESCRIPTION
## Summary
- avoid NaNs when computing track offset
- bump version number

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68860ab21ec483298c5e15b9f465142d