### PR TITLE
Fix NaN speed after starting simulation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.72",
+  "version": "1.0.73",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -304,16 +304,14 @@ setInterval(() => {
 }, 100);
 
 setInterval(() => {
-  if (speedIndicator) {
-    if (selectedIndex !== null) {
-      const vel = riders[selectedIndex].body.linvel();
-      const speed = Math.hypot(vel.x, vel.y, vel.z);
-      const kmh = speed * 3.6;
-      const text = `Speed: ${kmh.toFixed(1)} km/h`;
-      speedIndicator.textContent = text;
-    } else {
-      speedIndicator.textContent = '';
-    }
+  if (!speedIndicator) return;
+  if (selectedIndex !== null) {
+    const { x, y, z } = riders[selectedIndex].body.linvel();
+    const speed = Math.hypot(x, y, z);
+    const kmh = Number.isFinite(speed) ? speed * 3.6 : 0;
+    speedIndicator.textContent = `Speed: ${kmh.toFixed(1)} km/h`;
+  } else {
+    speedIndicator.textContent = '';
   }
 }, 100);
 


### PR DESCRIPTION
## Summary
- fix speed indicator when rider velocity contains invalid values
- bump version to 1.0.73

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68860c6f0aa88329b51a8b2c4963eefd