### PR TITLE
Fix timestep usage in physics world

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.76",
+  "version": "1.0.77",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/core/physicsWorld.js
+++ b/src/core/physicsWorld.js
@@ -14,7 +14,7 @@ world.integrationParameters.numAdditionalFrictionIterations = 40;
 
 let physicsAccumulator = 0;
 const fixedTimeStep = 1 / 60;
-world.timestep = fixedTimeStep;
+world.integrationParameters.dt = fixedTimeStep;
 /**
  * Avance la simulation physique par pas fixes.
  *

--- a/src/logic/leaderTraceExample.js
+++ b/src/logic/leaderTraceExample.js
@@ -77,7 +77,7 @@ function animate() {
     const vel = follower.body.linvel();
     const forceX = dx * 5 - vel.x;
     follower.body.setLinvel(
-      { x: vel.x + forceX * world.timestep, y: 0, z: vel.z },
+      { x: vel.x + forceX * world.integrationParameters.dt, y: 0, z: vel.z },
       true
     );
     follower.body.setTranslation({ x: pos.x, y: 0, z: pos.z + dz * 0.2 }, true);


### PR DESCRIPTION
## Summary
- use Rapier's `integrationParameters.dt` instead of custom `world.timestep`
- update leader trace example to reflect new field
- bump version to 1.0.77

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68862c8984e083299d7a9c56567d4430