### PR TITLE
Refine overlap handling with Rapier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.71",
+  "version": "1.0.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.71",
+      "version": "1.0.80",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.79",
+  "version": "1.0.80",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/overlapResolver.js
+++ b/src/logic/overlapResolver.js
@@ -1,6 +1,10 @@
 import { RIDER_WIDTH, MIN_LATERAL_GAP } from '../entities/riderConstants.js';
+import { devLog } from '../utils/devLog.js';
 
-const OVERLAP_FORCE = 10;
+// Rapier utilise des unités m/s. Un réglage trop élevé expulse
+// violemment les coureurs ; 5 offre une séparation visible sans
+// créer d'instabilités.
+const OVERLAP_FORCE = 5;
 
 /**
  * Resolve rider overlaps gradually by applying velocity adjustments.
@@ -25,6 +29,7 @@ function resolveOverlaps(riders) {
         if (distSq < minDist * minDist && distSq > 1e-6) {
           const dist = Math.sqrt(distSq);
           const overlap = minDist - dist;
+          devLog('Overlap detected', { a: i, b: j, overlap: overlap.toFixed(3) });
           const nx = dx / dist;
           const nz = dz / dist;
           const adjust = (overlap / 2) * OVERLAP_FORCE;
@@ -42,7 +47,7 @@ function resolveOverlaps(riders) {
           const relVZ = av2.z - bv2.z;
           const relVN = relVX * nx + relVZ * nz;
           if (relVN < 0) {
-            const impulse = relVN / 2;
+            const impulse = Math.max(relVN / 2, -overlap * OVERLAP_FORCE);
             a.body.setLinvel(
               { x: av2.x - impulse * nx, y: av2.y, z: av2.z - impulse * nz },
               true

--- a/src/utils/devLog.js
+++ b/src/utils/devLog.js
@@ -1,4 +1,6 @@
-const devMode = new URLSearchParams(window.location.search).has('dev');
+const devMode =
+  typeof window !== 'undefined' &&
+  new URLSearchParams(window.location.search).has('dev');
 
 function devLog(...args) {
   if (devMode) console.log(...args);


### PR DESCRIPTION
## Summary
- tweak overlap force for Rapier physics
- add debug logging for detected overlaps
- cap collision impulse to avoid violent separation
- make `devLog` safe in Node
- bump version to 1.0.80

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68862ffbff208329973c5e4c34034438