### PR TITLE
Fix NaN values in physics calculations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.79",
+  "version": "1.0.80",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -165,9 +165,11 @@ function clampAndRedirect() {
     v.y = 0;
     const radial = Math.hypot(p.x, p.z);
     if (radial < minR || radial > maxR) {
-      const nx = p.x / radial,
-        nz = p.z / radial;
-      const clamped = THREE.MathUtils.clamp(radial, minR, maxR);
+      // Si un coureur se retrouve exactement au centre, son rayon est nul
+      // ce qui produirait des valeurs NaN lors de la normalisation.
+      const nx = radial > 0 ? p.x / radial : 1;
+      const nz = radial > 0 ? p.z / radial : 0;
+      const clamped = THREE.MathUtils.clamp(radial || minR, minR, maxR);
       r.body.setTranslation({ x: nx * clamped, y: 0, z: nz * clamped }, true);
       const tangent = new RAPIER.Vector3(-nz, 0, nx);
       const speed = v.x * tangent.x + v.z * tangent.z;


### PR DESCRIPTION
## Summary
- guard against zero radius in `clampAndRedirect` to prevent NaN positions
- bump version to 1.0.80

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6886309afe8483299575f24654ea77c2