### PR TITLE
Tune draft factors for Rapier

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ Dans le navigateur, Rapier peut être chargé depuis un CDN avec :
 </script>
 ```
 
+## Constantes supplémentaires
+
+Deux nouvelles constantes sont définies dans `src/utils/constants.js` :
+
+- `BASE_LINEAR_DAMPING` : amortissement de base appliqué aux coureurs avant la traînée.
+- `DRAFT_FACTOR_SCALE` : intensité du bonus de vitesse lié à l'aspiration.
+
 ## Conventions de nommage
 
 - Les modules JavaScript (`.js`) utilisent le lower camelCase (`monModule.js`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.80",
+  "version": "1.0.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.80",
+      "version": "1.0.81",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.80",
+  "version": "1.0.81",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/draftLogic.js
+++ b/src/logic/draftLogic.js
@@ -1,4 +1,5 @@
 import { aheadDistance } from '../utils/utils.js';
+import { BASE_LINEAR_DAMPING, DRAFT_FACTOR_SCALE } from '../utils/constants.js';
 
 function updateDraftFactors(riders, windDirection = 1) {
   riders.forEach(r => {
@@ -36,8 +37,8 @@ function updateDraftFactors(riders, windDirection = 1) {
     if (!sheltered && windDirection !== 0) drag = Math.min(1, drag + 0.2);
     if (r.bordurePenalty) drag = Math.min(1, drag + r.bordurePenalty);
 
-    r.body.linearDamping = 0.2 * drag;
-    r.draftFactor = 1 + 0.625 * (1 - drag);
+    r.body.linearDamping = BASE_LINEAR_DAMPING * drag;
+    r.draftFactor = 1 + DRAFT_FACTOR_SCALE * (1 - drag);
 
     if (
       r.isLeader &&

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -14,6 +14,11 @@ const BREAKAWAY_MIN_GAP = 15;
 const BREAKAWAY_MAX_GAP = 40;
 const BORDURE_LANE_GAP = 1.0;
 
+// Amortissement de base appliqué aux coureurs avant la traînée
+const BASE_LINEAR_DAMPING = 0.15;
+// Intensité de l'effet d'aspiration sur la vitesse
+const DRAFT_FACTOR_SCALE = 0.7;
+
 // Multiplicateurs de fatigue liés à l'exposition au vent
 const SHELTERED_WIND_FATIGUE = 1.0;
 const EXPOSED_WIND_FATIGUE = 1.5;
@@ -31,5 +36,7 @@ export {
   BREAKAWAY_MAX_GAP,
   BORDURE_LANE_GAP,
   SHELTERED_WIND_FATIGUE,
-  EXPOSED_WIND_FATIGUE
+  EXPOSED_WIND_FATIGUE,
+  BASE_LINEAR_DAMPING,
+  DRAFT_FACTOR_SCALE
 };

--- a/test/draftFactor.test.js
+++ b/test/draftFactor.test.js
@@ -19,8 +19,8 @@ function testLinePositions() {
   const riders = [makeRider(10), makeRider(8), makeRider(6), makeRider(4), makeRider(2)];
   updateDraftFactors(riders, 0);
   approx(riders[0].draftFactor, 1.0);
-  approx(riders[1].draftFactor, 1.19);
-  approx(riders[4].draftFactor, 1.31);
+  approx(riders[1].draftFactor, 1.21);
+  approx(riders[4].draftFactor, 1.35);
 }
 
 function testDeepGroup() {
@@ -35,7 +35,7 @@ function testDeepGroup() {
   ];
   updateDraftFactors(riders, 0);
   assert.ok(riders[6].draftFactor > 1.5);
-  approx(riders[6].body.linearDamping, 0.01);
+  approx(riders[6].body.linearDamping, 0.0075);
 }
 
 testLinePositions();


### PR DESCRIPTION
## Summary
- adjust draft damping and factor scaling for Rapier physics
- expose `BASE_LINEAR_DAMPING` and `DRAFT_FACTOR_SCALE` constants
- document new constants in README
- update draft factor tests
- bump version to 1.0.81

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68863177e3fc8329a088261491b8eac0