### PR TITLE
Fix speed display with Rapier

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.81",
+  "version": "1.0.82",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -487,6 +487,10 @@ function animate() {
       loggedStartFrame = true;
     }
     stepPhysics(dt);
+    riders.forEach(r => {
+      const v = r.body.linvel();
+      r.speed = Math.hypot(v.x, v.y, v.z) * 3.6;
+    });
     sanitizeRiders();
     const first = riders[0];
     if (first) {

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -306,9 +306,9 @@ setInterval(() => {
 setInterval(() => {
   if (!speedIndicator) return;
   if (selectedIndex !== null) {
-    const { x, y, z } = riders[selectedIndex].body.linvel();
-    const speed = Math.hypot(x, y, z);
-    const kmh = Number.isFinite(speed) ? speed * 3.6 : 0;
+    const kmh = Number.isFinite(riders[selectedIndex].speed)
+      ? riders[selectedIndex].speed
+      : 0;
     speedIndicator.textContent = `Speed: ${kmh.toFixed(1)} km/h`;
   } else {
     speedIndicator.textContent = '';


### PR DESCRIPTION
## Summary
- avoid linvel conflicts when displaying speed
- cache each rider's speed right after physics updates
- show cached speed in the UI
- bump version to 1.0.82

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688880c521a883298ac299d1a48ea96f