### PR TITLE
Handle physics crashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.82",
+  "version": "1.0.83",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -17,7 +17,7 @@ import {
 } from '../entities/track.js';
 import { stepPhysics } from '../core/physicsWorld.js';
 import { updateSelectionHelper, selectedIndex } from '../ui/ui.js';
-import { started } from '../ui/startButton.js';
+import { started, setStarted } from '../ui/startButton.js';
 import { aheadDistance, wrapDistance, polarToDist } from '../utils/utils.js';
 import { updateDraftFactors as computeDraftFactors } from './draftLogic.js';
 import { updateBordure } from './bordureLogic.js';
@@ -486,7 +486,12 @@ function animate() {
       });
       loggedStartFrame = true;
     }
-    stepPhysics(dt);
+    try {
+      stepPhysics(dt);
+    } catch (e) {
+      console.error('Crash physics:', e);
+      setStarted(false);
+    }
     riders.forEach(r => {
       const v = r.body.linvel();
       r.speed = Math.hypot(v.x, v.y, v.z) * 3.6;

--- a/src/ui/startButton.js
+++ b/src/ui/startButton.js
@@ -11,6 +11,10 @@ import { camera } from '../core/setupScene.js';
 
 let started = false;
 
+function setStarted(value) {
+  started = value;
+}
+
 const startBtn = document.getElementById('startBtn');
 if (startBtn) {
   startBtn.addEventListener('click', () => {
@@ -52,4 +56,4 @@ if (startBtn) {
   });
 }
 
-export { started };
+export { started, setStarted };


### PR DESCRIPTION
## Summary
- wrap `stepPhysics` with try/catch in the animation loop
- allow resetting the `started` flag
- bump version to 1.0.83

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688897d68414832981cffe8df9fcb63c