### PR TITLE
Fix Rapier init warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.81",
+  "version": "1.0.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.81",
+      "version": "1.0.84",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.83",
+  "version": "1.0.84",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/core/physicsWorld.js
+++ b/src/core/physicsWorld.js
@@ -2,10 +2,7 @@
 
 import RAPIER from '@dimforge/rapier3d';
 
-await RAPIER.init({
-  locateFile: () =>
-    new URL('@dimforge/rapier3d/rapier_wasm3d_bg.wasm', import.meta.url).href,
-});
+await RAPIER.init();
 
 const world = new RAPIER.World({ gravity: { x: 0, y: 0, z: 0 } });
 // Augmente le nombre d'itérations du solveur pour mieux gérer les collisions dans un peloton dense


### PR DESCRIPTION
## Summary
- initialize Rapier without deprecated parameters
- bump version to 1.0.84

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68889a4902b8832985dd673d9fa0f5fb