### PR TITLE
Fix rapier init options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.84",
+  "version": "1.0.85",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.84",
+      "version": "1.0.85",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.84",
+  "version": "1.0.85",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/core/physicsWorld.js
+++ b/src/core/physicsWorld.js
@@ -2,7 +2,9 @@
 
 import RAPIER from '@dimforge/rapier3d';
 
-await RAPIER.init();
+// Pass an empty object to explicitly set options and avoid default path lookups
+// that can trigger bundler warnings
+await RAPIER.init({});
 
 const world = new RAPIER.World({ gravity: { x: 0, y: 0, z: 0 } });
 // Augmente le nombre d'itérations du solveur pour mieux gérer les collisions dans un peloton dense


### PR DESCRIPTION
## Summary
- initialize Rapier with an empty options object
- bump patch version to 1.0.85

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688b32a848908329809989cc23d6f926