### PR TITLE
Fix translation update in animation logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.86",
+  "version": "1.0.87",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -585,7 +585,6 @@ function animate() {
     const lookAtPoint = new THREE.Vector3(r.mesh.position.x + dx, 0, r.mesh.position.z + dz);
     r.mesh.lookAt(lookAtPoint);
     r.mesh.rotateY(-Math.PI / 2);
-    r.body.setTranslation({ x: bodyPos.x, y: 0, z: bodyPos.z }, false);
     r.body.setRotation(
       {
         x: r.mesh.quaternion.x,


### PR DESCRIPTION
## Summary
- remove unused `setTranslation` call in animation logic
- bump version to 1.0.87

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688b361948048329956d3951d0df1c98