### PR TITLE
Update RAPIER init and bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.85",
+  "version": "1.0.88",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.85",
+      "version": "1.0.88",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.87",
+  "version": "1.0.88",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/leaderTraceExample.js
+++ b/src/logic/leaderTraceExample.js
@@ -5,7 +5,7 @@
 import * as THREE from 'three';
 import RAPIER from '@dimforge/rapier3d';
 
-await RAPIER.init();
+await RAPIER.init({});
 
 // Paramètres principaux
 const NUM_RUNNERS = 5; // leader compris


### PR DESCRIPTION
## Summary
- use `await RAPIER.init({});`
- bump version to 1.0.88
- update lockfile

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688b377c6bd48329990fbe04fec0a0d0