### PR TITLE
Fix deprecated Rapier init warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.88",
+  "version": "1.0.89",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.88",
+      "version": "1.0.89",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.88",
+  "version": "1.0.89",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/core/physicsWorld.js
+++ b/src/core/physicsWorld.js
@@ -2,9 +2,8 @@
 
 import RAPIER from '@dimforge/rapier3d';
 
-// Pass an empty object to explicitly set options and avoid default path lookups
-// that can trigger bundler warnings
-await RAPIER.init({});
+// Compat build expects init without arguments
+await RAPIER.init();
 
 const world = new RAPIER.World({ gravity: { x: 0, y: 0, z: 0 } });
 // Augmente le nombre d'itérations du solveur pour mieux gérer les collisions dans un peloton dense

--- a/src/logic/leaderTraceExample.js
+++ b/src/logic/leaderTraceExample.js
@@ -5,7 +5,8 @@
 import * as THREE from 'three';
 import RAPIER from '@dimforge/rapier3d';
 
-await RAPIER.init({});
+// Compat build expects init without arguments
+await RAPIER.init();
 
 // Paramètres principaux
 const NUM_RUNNERS = 5; // leader compris


### PR DESCRIPTION
## Summary
- prevent runtime warning by calling `RAPIER.init()` with no params
- bump version to 1.0.89

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688b39b25b048329b653d490b576ee45