### PR TITLE
feat: make simulation start idempotent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.89",
+  "version": "1.0.90",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -8,9 +8,9 @@ import '../ui/ui.js';
 import '../ui/startButton.js';
 import '../ui/soundToggle.js';
 import initVersion from '../utils/version.js';
-import { animate } from '../logic/animation.js';
+import { startSimulation } from '../logic/animation.js';
 import { initCameraControls } from '../logic/cameraController.js';
 
 initCameraControls();
-animate();
+startSimulation();
 initVersion();

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -29,6 +29,10 @@ import { emit } from '../utils/eventBus.js';
 import { updateBreakaway } from './breakawayManager.js';
 import { devLog } from '../utils/devLog.js';
 
+let rafId = null;
+let running = false;
+let stepping = false;
+
 const SPEED_GAIN = 0.3;
 // On mélange moins avec la trajectoire idéale pour que les collisions physiques aient plus d'influence
 const IDEAL_MIX = 0.3;
@@ -469,8 +473,7 @@ function applyForces(dt) {
  *
  * @returns {void}
  */
-function animate() {
-  requestAnimationFrame(animate);
+function loop() {
 
   const now = performance.now();
   const dt = Math.min((now - lastTime) / 1000, 0.1);
@@ -599,6 +602,23 @@ function animate() {
   updateSelectionHelper();
   updateCamera();
   renderer.render(scene, camera);
+
+  if (running || stepping) {
+    rafId = requestAnimationFrame(loop);
+    stepping = false;
+  }
 }
 
-export { animate, updateLaneOffsets };
+export function startSimulation() {
+  if (running) return;
+  running = true;
+  rafId = requestAnimationFrame(loop);
+}
+
+export function stopSimulation() {
+  running = false;
+  if (rafId) cancelAnimationFrame(rafId);
+  rafId = null;
+}
+
+export { updateLaneOffsets };


### PR DESCRIPTION
## Summary
- prevent multiple animation loops by tracking RAF state
- expose start and stop controls for the simulation
- bump version to 1.0.90

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68973f3b9564832992f72e7cabd7db5b