### PR TITLE
refactor: remove redundant velocity resets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.89",
+  "version": "1.0.90",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/ui/startButton.js
+++ b/src/ui/startButton.js
@@ -28,9 +28,6 @@ if (startBtn) {
       r.intensity = r.baseIntensity;
       emit('intensityChange', { rider: r, value: r.intensity });
       const pos = r.body.translation();
-      // Laisse la physique accélérer progressivement
-      r.body.setLinvel(new RAPIER.Vector3(0, 0, 0), true);
-      r.body.setAngvel({ x: 0, y: 0, z: 0 }, true);
       r.body.resetForces();
       r.mesh.position.copy(pos);
       r.trackDist = polarToDist(pos.x, pos.z);


### PR DESCRIPTION
## Summary
- remove unnecessary zeroing of rider velocities in start button handler
- bump version to 1.0.90

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68973f48b020832986e90d7ba79719c3