### PR TITLE
Use Rapier 3D compat module directly

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,9 +11,7 @@
       {
         "imports": {
           "three": "https://unpkg.com/three@0.153.0/build/three.module.js",
-          "three/addons/": "https://unpkg.com/three@0.153.0/examples/jsm/",
-          "@dimforge/rapier3d": "https://unpkg.com/@dimforge/rapier3d-compat@0.18.0/rapier.mjs?module",
-          "@dimforge/rapier3d/rapier.js": "https://unpkg.com/@dimforge/rapier3d-compat@0.18.0/rapier.mjs?module"
+          "three/addons/": "https://unpkg.com/three@0.153.0/examples/jsm/"
         }
       }
     </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.89",
+  "version": "1.0.90",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.89",
+      "version": "1.0.90",
       "license": "ISC",
       "dependencies": {
-        "@dimforge/rapier3d": "^0.18.0",
         "@dimforge/rapier3d-compat": "^0.18.0"
       },
       "devDependencies": {
@@ -145,12 +144,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/@dimforge/rapier3d": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d/-/rapier3d-0.18.0.tgz",
-      "integrity": "sha512-Gzpn3E8jZUrFeGlxizc09hT6DbTI4RDSl8dpeiGYUy4OJA7dj/jrTGuhHWKddXh/6MCgYqmBwuADLJoqnBH1Hw==",
-      "license": "Apache-2.0"
     },
     "node_modules/@dimforge/rapier3d-compat": {
       "version": "0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.89",
+  "version": "1.0.90",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {
@@ -17,7 +17,6 @@
     "jsdom": "^24.0.0"
   },
   "dependencies": {
-    "@dimforge/rapier3d": "^0.18.0",
     "@dimforge/rapier3d-compat": "^0.18.0"
   }
 }

--- a/src/core/physicsWorld.js
+++ b/src/core/physicsWorld.js
@@ -1,6 +1,6 @@
 // Initialise le monde physique Rapier et gère le pas de simulation
 
-import RAPIER from '@dimforge/rapier3d';
+import RAPIER from 'https://unpkg.com/@dimforge/rapier3d-compat@0.18.0/rapier.mjs?module';
 
 // Compat build expects init without arguments
 await RAPIER.init();

--- a/src/logic/leaderTraceExample.js
+++ b/src/logic/leaderTraceExample.js
@@ -3,7 +3,7 @@
 // Chaque suiveur vise une ancienne position du leader pour former une file indienne
 
 import * as THREE from 'three';
-import RAPIER from '@dimforge/rapier3d';
+import RAPIER from 'https://unpkg.com/@dimforge/rapier3d-compat@0.18.0/rapier.mjs?module';
 
 // Compat build expects init without arguments
 await RAPIER.init();


### PR DESCRIPTION
## Summary
- load Rapier from the 3D compat build and await initialization
- drop unused @dimforge/rapier3d dependency and import-map entries
- bump package version to 1.0.90

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68973f5269288329975076c275904f76