### PR TITLE
refactor: split overlap solver into read/write passes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.89",
+  "version": "1.0.90",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.89",
+      "version": "1.0.90",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.89",
+  "version": "1.0.90",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -4,7 +4,10 @@ import { THREE, scene, camera, renderer } from '../core/setupScene.js';
 import { RAPIER } from '../core/physicsWorld.js';
 import { riders } from '../entities/riders.js';
 import { RIDER_WIDTH, MIN_LATERAL_GAP } from '../entities/riderConstants.js';
-import { resolveOverlaps } from './overlapResolver.js';
+import {
+  computeOverlapCommands,
+  applyOverlapCommands
+} from './overlapResolver.js';
 import {
   outerSpline,
   innerSpline,
@@ -546,7 +549,8 @@ function animate() {
     updateLaneOffsets(dt);
     updateRelays(dt);
     applyForces(dt);
-    resolveOverlaps(riders);
+    const overlapCmds = computeOverlapCommands(riders);
+    applyOverlapCommands(overlapCmds);
   }
 
 

--- a/test/overlapResolution.test.js
+++ b/test/overlapResolution.test.js
@@ -1,5 +1,8 @@
 import assert from 'node:assert';
-import { resolveOverlaps } from '../src/logic/overlapResolver.js';
+import {
+  computeOverlapCommands,
+  applyOverlapCommands
+} from '../src/logic/overlapResolver.js';
 
 function makeRider(x, z) {
   const body = {
@@ -31,7 +34,8 @@ function testNoTeleport() {
   const r2 = makeRider(0.5, 0); // closer than min distance
   const riders = [r1, r2];
 
-  resolveOverlaps(riders);
+  const cmds = computeOverlapCommands(riders);
+  applyOverlapCommands(cmds);
 
   // positions should remain unchanged after resolution step
   assert.strictEqual(r1.body.position.x, 0);


### PR DESCRIPTION
## Summary
- split overlap resolver into compute/apply phases so reads and writes are separated
- update animation loop and tests to use new overlap commands
- bump package version to 1.0.90

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68973f5b7f5c83298dfd318a290cf083