### PR TITLE
fix: remove duplicate stepping declaration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.90",
+  "version": "1.0.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.90",
+      "version": "1.0.91",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.90",
+  "version": "1.0.91",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -71,7 +71,6 @@ function setIntensity(rider, value) {
 let lastTime = performance.now();
 let loggedStartFrame = false;
 const eventQueue = new RAPIER.EventQueue(true);
-let stepping = false;
 
 /**
  * Limite la vitesse maximale des coureurs pour éviter des accélérations
@@ -469,7 +468,7 @@ function applyForces(dt) {
  * @param {number} dt Intervalle de temps en secondes.
  * @returns {void}
  */
-function loop(dt) {
+function stepSimulation(dt) {
   if (stepping) return;
   stepping = true;
 
@@ -553,7 +552,7 @@ function loop() {
       loggedStartFrame = true;
     }
     try {
-      loop(dt);
+      stepSimulation(dt);
     } catch (e) {
       console.error('Crash physics:', e);
       setStarted(false);


### PR DESCRIPTION
## Summary
- remove duplicate `stepping` declaration in animation logic
- rename simulation step function to `stepSimulation`
- bump version to 1.0.91

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6898a4771b7c8329b955ce638a60b8fa