### PR TITLE
fix redeclarations and bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.90",
+  "version": "1.0.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.90",
+    "version": "1.0.91",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.90",
+  "version": "1.0.91",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -74,7 +74,6 @@ function setIntensity(rider, value) {
 let lastTime = performance.now();
 let loggedStartFrame = false;
 const eventQueue = new RAPIER.EventQueue(true);
-let stepping = false;
 
 /**
  * Limite la vitesse maximale des coureurs pour éviter des accélérations
@@ -472,7 +471,7 @@ function applyForces(dt) {
  * @param {number} dt Intervalle de temps en secondes.
  * @returns {void}
  */
-function loop(dt) {
+function step(dt) {
   if (stepping) return;
   stepping = true;
 
@@ -556,7 +555,7 @@ function loop() {
       loggedStartFrame = true;
     }
     try {
-      loop(dt);
+      step(dt);
     } catch (e) {
       console.error('Crash physics:', e);
       setStarted(false);


### PR DESCRIPTION
## Summary
- remove duplicate `stepping` declaration in animation logic
- rename simulation step function to avoid loop redeclaration
- bump package version to 1.0.91

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6898a5703e148329a26239d77807508f