### PR TITLE
Fix animation loop recursion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.91",
+  "version": "1.0.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-    "version": "1.0.91",
+      "version": "1.0.92",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.91",
+  "version": "1.0.92",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -472,7 +472,7 @@ function applyForces(dt) {
  * @returns {void}
  */
 
-function step(dt) {
+function simulateStep(dt) {
   if (stepping) return;
   stepping = true;
 
@@ -557,7 +557,7 @@ function loop() {
     }
     try {
 
-      step(dt);
+      simulateStep(dt);
 
     } catch (e) {
       console.error('Crash physics:', e);


### PR DESCRIPTION
## Summary
- rename physics step function to `simulateStep` to avoid clobbering animation loop
- call `simulateStep` from animation loop to prevent infinite recursion
- bump version to 1.0.92

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6898a6eeca6c832984c3e7535a3ac35a