### PR TITLE
refactor: rename relay cluster flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.91",
+  "version": "1.0.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-    "version": "1.0.91",
+    "version": "1.0.92",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.91",
+  "version": "1.0.92",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/entities/riders.js
+++ b/src/entities/riders.js
@@ -105,7 +105,7 @@ for (let team = 0; team < NUM_TEAMS; team++) {
       relayPhase: 'line',
       relayTimer: 0,
       relayTime: 0,
-      isRelayLeader: false,
+      inRelayCluster: false,
       protectLeader: false,
       mesh,
       body    });

--- a/src/logic/relayCluster.js
+++ b/src/logic/relayCluster.js
@@ -24,7 +24,7 @@ function updateRelayCluster(riderList) {
   relayCluster.stdDev = res.stdDev;
   relayCluster.members = res.members;
   riderList.forEach(r => {
-    r.isRelayLeader = relayCluster.members.includes(r);
+    r.inRelayCluster = relayCluster.members.includes(r);
   });
 }
 


### PR DESCRIPTION
## Summary
- rename `isRelayLeader` to `inRelayCluster` on rider objects
- update relay cluster logic to mark `inRelayCluster` members
- bump version to 1.0.92

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6898a6f501cc8329af4eada236925d1d