### PR TITLE
fix: use new overlap resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.91",
+  "version": "1.0.92",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -525,7 +525,8 @@ function step(dt) {
   updateLaneOffsets(dt);
   updateRelays(dt);
   applyForces(dt);
-  resolveOverlaps(riders);
+  const overlapCmds = computeOverlapCommands(riders);
+  applyOverlapCommands(overlapCmds);
   riders.forEach(r => {
     const v = r.body.linvel();
     r.speed = Math.hypot(v.x, v.y, v.z) * 3.6;


### PR DESCRIPTION
## Summary
- replace direct resolveOverlaps call with compute/apply overlap commands
- bump version to 1.0.92

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6898a74f24348329a641c6bee7790b91