### PR TITLE
Fix overlap resolution in animation loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.92",
+  "version": "1.0.93",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -493,7 +493,7 @@ function simulateStep(dt) {
     });
     adjustIntensityToLeader();
 
-    const commands = snapshot.map(s => {
+    const forceCommands = snapshot.map(s => {
       const r = s.rider;
       const theta = ((r.trackDist % TRACK_WRAP) / TRACK_WRAP) * 2 * Math.PI;
       const forward = new RAPIER.Vector3(-Math.sin(theta), 0, Math.cos(theta));
@@ -517,7 +517,7 @@ function simulateStep(dt) {
     world.step(eventQueue);
 
     // WRITE phase
-    commands.forEach(cmd => {
+    forceCommands.forEach(cmd => {
       cmd.rider.body.addForce(cmd.force, true);
     });
     sanitizeRiders();
@@ -527,7 +527,8 @@ function simulateStep(dt) {
     updateLaneOffsets(dt);
     updateRelays(dt);
     applyForces(dt);
-    resolveOverlaps(riders);
+    const overlapCommands = computeOverlapCommands(riders);
+    applyOverlapCommands(overlapCommands);
     riders.forEach(r => {
       const v = r.body.linvel();
       r.speed = Math.hypot(v.x, v.y, v.z) * 3.6;


### PR DESCRIPTION
## Summary
- use `computeOverlapCommands`/`applyOverlapCommands` instead of undefined `resolveOverlaps`
- rename internal force command variable for clarity
- bump version to 1.0.93

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6898a8f896348329be181694a6155698