### PR TITLE
Fix Rapier initialization and overlap resolution API usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.92",
+  "version": "1.0.93",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/core/physicsWorld.js
+++ b/src/core/physicsWorld.js
@@ -2,8 +2,8 @@
 
 import RAPIER from 'https://unpkg.com/@dimforge/rapier3d-compat@0.18.0/rapier.mjs?module';
 
-// Compat build expects init without arguments
-await RAPIER.init();
+// Rapier requiert désormais un objet (même vide) pour l'initialisation
+await RAPIER.init({});
 
 const world = new RAPIER.World({ gravity: { x: 0, y: 0, z: 0 } });
 // Augmente le nombre d'itérations du solveur pour mieux gérer les collisions dans un peloton dense

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -527,7 +527,8 @@ function simulateStep(dt) {
     updateLaneOffsets(dt);
     updateRelays(dt);
     applyForces(dt);
-    resolveOverlaps(riders);
+    const cmds = computeOverlapCommands(riders);
+    applyOverlapCommands(cmds);
     riders.forEach(r => {
       const v = r.body.linvel();
       r.speed = Math.hypot(v.x, v.y, v.z) * 3.6;


### PR DESCRIPTION
## Summary
- initialize Rapier with an empty options object to avoid deprecation warnings
- replace obsolete `resolveOverlaps` call with new compute/apply overlap command sequence
- bump package version to 1.0.93

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6898aa0023648329958a06e6a549e66c