### PR TITLE
Initialize Rapier with options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.92",
+  "version": "1.0.94",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-    "version": "1.0.92",
+      "version": "1.0.94",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.93",
+  "version": "1.0.94",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/leaderTraceExample.js
+++ b/src/logic/leaderTraceExample.js
@@ -5,8 +5,8 @@
 import * as THREE from 'three';
 import RAPIER from 'https://unpkg.com/@dimforge/rapier3d-compat@0.18.0/rapier.mjs?module';
 
-// Compat build expects init without arguments
-await RAPIER.init();
+// Initialize Rapier
+await RAPIER.init({});
 
 // Paramètres principaux
 const NUM_RUNNERS = 5; // leader compris


### PR DESCRIPTION
## Summary
- initialize Rapier with an explicit empty options object
- bump package version to 1.0.94

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6898ace652108329bef5be7becb90cea