### PR TITLE
Sanitize riders before physics step

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.92",
+  "version": "1.0.94",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-    "version": "1.0.92",
+      "version": "1.0.94",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.93",
+  "version": "1.0.94",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -474,6 +474,7 @@ function applyForces(dt) {
 
 function simulateStep(dt) {
   if (stepping) return;
+  sanitizeRiders();
   stepping = true;
 
   try {


### PR DESCRIPTION
## Summary
- Sanitize riders at the start of each simulation step to prevent invalid physics states
- Bump version to 1.0.94

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6898ad436fcc8329bbbb59b7eea3da62