### PR TITLE
chore: update rapier3d-compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.92",
+  "version": "1.0.94",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-    "version": "1.0.92",
+      "version": "1.0.94",
       "license": "ISC",
       "dependencies": {
-        "@dimforge/rapier3d-compat": "^0.18.0"
+        "@dimforge/rapier3d-compat": "^0.18.1"
       },
       "devDependencies": {
         "eslint": "^9.31.0",
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@dimforge/rapier3d-compat": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.18.0.tgz",
-      "integrity": "sha512-/H92Afd3RJ2PIx8TKtSG8Apb+hmnOKL1kJKFfTGVpab1ujYm3nhub3oTfC3mVlWoRx+yURxYjddjAe3cgP3tgw==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.18.1.tgz",
+      "integrity": "sha512-ogfkrMpRsB0osDAqnhO6fD3s2hCrwAdNFqs36U2N0aogu38tbWDtMfxQzWqjTMkJ4x8QV402Me6fggNykZECUg==",
       "license": "Apache-2.0"
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.93",
+  "version": "1.0.94",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {
@@ -17,6 +17,6 @@
     "jsdom": "^24.0.0"
   },
   "dependencies": {
-    "@dimforge/rapier3d-compat": "^0.18.0"
+    "@dimforge/rapier3d-compat": "^0.18.1"
   }
 }


### PR DESCRIPTION
## Summary
- upgrade @dimforge/rapier3d-compat to latest 0.18.x release
- bump package version to 1.0.94

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6898ad4538bc832987b6125ccbe4b905