### PR TITLE
Handle physics step failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.95",
+  "version": "1.0.96",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.95",
+      "version": "1.0.96",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.18.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.95",
+  "version": "1.0.96",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -569,6 +569,7 @@ function loop() {
     } catch (e) {
       console.error('Crash physics:', e);
       setStarted(false);
+      return;
     }
     riders.forEach(r => {
       const v = r.body.linvel();


### PR DESCRIPTION
## Summary
- stop processing animation frame when physics step crashes to avoid cascading errors
- bump version to 1.0.96

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689aefdc1ac88329aa592712465c260c