### PR TITLE
Fix Rapier initialization warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Dans le navigateur, Rapier peut être chargé depuis un CDN. On l'initialise ens
 
 ```html
 <script type="module">
-  import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat';
-  await RAPIER.init();
+  import initRAPIER, * as RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat';
+  await initRAPIER();
 </script>
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.97",
+  "version": "1.0.98",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.97",
+      "version": "1.0.98",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.18.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.97",
+  "version": "1.0.98",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/core/physicsWorld.js
+++ b/src/core/physicsWorld.js
@@ -1,9 +1,9 @@
 // Initialise le monde physique Rapier et gère le pas de simulation
 
-import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat';
+import initRAPIER, * as RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat';
 
-// Rapier s'initialise désormais sans argument
-await RAPIER.init();
+// Initialisation de Rapier sans avertissement de paramètres obsolètes
+await initRAPIER();
 
 const world = new RAPIER.World({ gravity: { x: 0, y: 0, z: 0 } });
 // Augmente le nombre d'itérations du solveur pour mieux gérer les collisions dans un peloton dense

--- a/src/logic/leaderTraceExample.js
+++ b/src/logic/leaderTraceExample.js
@@ -3,10 +3,10 @@
 // Chaque suiveur vise une ancienne position du leader pour former une file indienne
 
 import * as THREE from 'three';
-import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat';
+import initRAPIER, * as RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat';
 
-// Initialize Rapier
-await RAPIER.init();
+// Initialise Rapier
+await initRAPIER();
 
 // Paramètres principaux
 const NUM_RUNNERS = 5; // leader compris


### PR DESCRIPTION
## Summary
- use explicit `init` function from Rapier to avoid deprecated parameters warning
- document new Rapier initialization usage
- bump version to 1.0.98

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689af7bd26888329aca5ef8c23d67b2c