### PR TITLE
Start button launches simulation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.99",
+  "version": "1.0.100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.99",
+    "version": "1.0.100",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.18.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.99",
+  "version": "1.0.100",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -8,9 +8,7 @@ import '../ui/ui.js';
 import '../ui/startButton.js';
 import '../ui/soundToggle.js';
 import initVersion from '../utils/version.js';
-import { startSimulation } from '../logic/animation.js';
 import { initCameraControls } from '../logic/cameraController.js';
 
 initCameraControls();
-startSimulation();
 initVersion();

--- a/src/ui/startButton.js
+++ b/src/ui/startButton.js
@@ -17,7 +17,7 @@ function setStarted(value) {
 
 const startBtn = document.getElementById('startBtn');
 if (startBtn) {
-  startBtn.addEventListener('click', () => {
+  startBtn.addEventListener('click', async () => {
     devLog('Start button clicked');
     started = true;
     resumeAmbientSound();
@@ -49,6 +49,8 @@ if (startBtn) {
       z: camera.position.z
     };
     devLog('Camera after resize', after);
+    const { startSimulation } = await import('../logic/animation.js');
+    startSimulation();
     startBtn.disabled = true;
   });
 }


### PR DESCRIPTION
## Summary
- Launch physics and animation when clicking **Start**, ensuring riders begin moving
- Remove automatic simulation start from main entry point
- Bump package version to 1.0.100

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689b1c8d32f8832980fb57b0040e8f74