### PR TITLE
fix: ensure start flag propagates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.99",
+  "version": "1.0.100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.99",
+      "version": "1.0.100",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.18.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.99",
+  "version": "1.0.100",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -19,7 +19,7 @@ import {
   ROAD_WIDTH
 } from '../entities/track.js';
 import { updateSelectionHelper, selectedIndex } from '../ui/ui.js';
-import { started, setStarted } from '../ui/startButton.js';
+import { isStarted, setStarted } from '../ui/startButton.js';
 import { aheadDistance, wrapDistance, polarToDist } from '../utils/utils.js';
 import { updateDraftFactors as computeDraftFactors } from './draftLogic.js';
 import { updateBordure } from './bordureLogic.js';
@@ -556,7 +556,7 @@ function loop() {
   const dt = Math.min((now - lastTime) / 1000, 0.1);
   lastTime = now;
 
-  if (started) {
+  if (isStarted()) {
     if (!loggedStartFrame) {
         const cam = camera.position;
         const firstPos = riders[0]?.body.translation();

--- a/src/ui/startButton.js
+++ b/src/ui/startButton.js
@@ -15,11 +15,15 @@ function setStarted(value) {
   started = value;
 }
 
+function isStarted() {
+  return started;
+}
+
 const startBtn = document.getElementById('startBtn');
 if (startBtn) {
   startBtn.addEventListener('click', () => {
     devLog('Start button clicked');
-    started = true;
+    setStarted(true);
     resumeAmbientSound();
     riders.forEach(r => {
       r.currentBoost = 0;
@@ -53,4 +57,4 @@ if (startBtn) {
   });
 }
 
-export { started, setStarted };
+export { isStarted, setStarted };


### PR DESCRIPTION
## Summary
- add getter and setter to share simulation start state
- rely on getter in animation loop to react to Start button

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689b4e0551b08329986d582458b8b790