### PR TITLE
Allow restarting simulation after physics crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.103",
+  "version": "1.0.104",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-    "version": "1.0.103",
+    "version": "1.0.104",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.18.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.103",
+  "version": "1.0.104",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -576,6 +576,8 @@ function loop() {
     } catch (e) {
       console.error('Crash physics:', e);
       setStarted(false);
+      running = false;
+      rafId = null;
       return;
     }
   }

--- a/src/ui/startButton.js
+++ b/src/ui/startButton.js
@@ -8,6 +8,7 @@ import { resumeAmbientSound } from '../logic/ambientSound.js';
 import { RAPIER } from '../core/physicsWorld.js';
 import { devLog } from '../utils/devLog.js';
 import { camera } from '../core/setupScene.js';
+import { startSimulation } from '../logic/animation.js';
 
 let started = false;
 
@@ -54,6 +55,7 @@ if (startBtn) {
       z: camera.position.z
     };
     devLog('Camera after resize', after);
+    startSimulation();
     startBtn.disabled = true;
   });
 }


### PR DESCRIPTION
## Summary
- Restart animation loop when the Start button is clicked
- Reset running state if physics simulation crashes
- Bump version to 1.0.104

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a4760d3f7083298285d1c409c6111c