### PR TITLE
Use fixed timestep physics stepping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.104",
+  "version": "1.0.105",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-    "version": "1.0.104",
+    "version": "1.0.105",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.18.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.104",
+  "version": "1.0.105",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -1,7 +1,7 @@
 // Animation du peloton et logique de comportement des coureurs
 
 import { THREE, scene, camera, renderer } from '../core/setupScene.js';
-import { RAPIER, world } from '../core/physicsWorld.js';
+import { RAPIER, stepPhysics } from '../core/physicsWorld.js';
 import { riders } from '../entities/riders.js';
 import { RIDER_WIDTH, MIN_LATERAL_GAP } from '../entities/riderConstants.js';
 import {
@@ -73,7 +73,6 @@ function setIntensity(rider, value) {
 
 let lastTime = performance.now();
 let loggedStartFrame = false;
-const eventQueue = new RAPIER.EventQueue(true);
 
 function cloneVec3(vec) {
   return { x: vec.x, y: vec.y, z: vec.z };
@@ -528,8 +527,8 @@ function simulateStep(dt) {
     });
     applyForces(dt);
 
-    // STEP phase
-    world.step(eventQueue);
+    // STEP phase – use fixed timestep stepping
+    stepPhysics(dt);
 
     // WRITE phase
     sanitizeRiders();


### PR DESCRIPTION
## Summary
- replace direct `world.step` with `stepPhysics` to allow multiple fixed physics steps per frame
- remove unused event queue
- bump version to 1.0.105

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a5a9c785f08329aeba2382d7ea8724