### PR TITLE
feat: add pause and reset controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,9 @@
     </div>
 
     <button id="startBtn" style="position: absolute; bottom: 10px; right: 10px; padding: 8px 12px; z-index: 100;">Start</button>
-    <button id="soundToggle" style="position: absolute; bottom: 10px; right: 70px; padding: 8px 12px; z-index: 100;">🔊</button>
+    <button id="resetBtn" style="position: absolute; bottom: 10px; right: 70px; padding: 8px 12px; z-index: 100;">Reset</button>
+    <button id="pauseBtn" style="position: absolute; bottom: 10px; right: 130px; padding: 8px 12px; z-index: 100;">Pause</button>
+    <button id="soundToggle" style="position: absolute; bottom: 10px; right: 190px; padding: 8px 12px; z-index: 100;">🔊</button>
 
     <div id="vis"></div>
     <div id="version-container"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.106",
+  "version": "1.0.107",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/ui/startButton.js
+++ b/src/ui/startButton.js
@@ -8,9 +8,10 @@ import { resumeAmbientSound } from '../logic/ambientSound.js';
 import { RAPIER } from '../core/physicsWorld.js';
 import { devLog } from '../utils/devLog.js';
 import { camera } from '../core/setupScene.js';
-import { startSimulation } from '../logic/animation.js';
+import { startSimulation, stopSimulation } from '../logic/animation.js';
 
 let started = false;
+let running = false;
 
 function setStarted(value) {
   started = value;
@@ -20,27 +21,34 @@ function isStarted() {
   return started;
 }
 
+function resetRiders() {
+  riders.forEach(r => {
+    r.currentBoost = 0;
+    r.isAttacking = false;
+    r.attackGauge = 100;
+    r.intensity = r.baseIntensity;
+    emit('intensityChange', { rider: r, value: r.intensity });
+    const pos = r.body.translation();
+    r.body.resetForces();
+    r.body.setLinvel({ x: 0, y: 0, z: 0 }, true);
+    r.mesh.position.copy(pos);
+    r.trackDist = polarToDist(pos.x, pos.z);
+    r.prevDist = r.trackDist;
+    r.lap = 0;
+  });
+  devLog('Riders repositioned', riders.map(r => r.body.translation()));
+}
+
 const startBtn = document.getElementById('startBtn');
+const resetBtn = document.getElementById('resetBtn');
+const pauseBtn = document.getElementById('pauseBtn');
+
 if (startBtn) {
   startBtn.addEventListener('click', () => {
     devLog('Start button clicked');
     setStarted(true);
     resumeAmbientSound();
-    riders.forEach(r => {
-      r.currentBoost = 0;
-      r.isAttacking = false;
-      r.attackGauge = 100;
-      r.intensity = r.baseIntensity;
-      emit('intensityChange', { rider: r, value: r.intensity });
-      const pos = r.body.translation();
-      r.body.resetForces();
-      r.body.setLinvel({ x: 0, y: 0, z: 0 }, true);
-      r.mesh.position.copy(pos);
-      r.trackDist = polarToDist(pos.x, pos.z);
-      r.prevDist = r.trackDist;
-      r.lap = 0;
-    });
-    devLog('Riders repositioned', riders.map(r => r.body.translation()));
+    resetRiders();
     // Force un recalcul de la taille du canvas au démarrage
     const before = {
       x: camera.position.x,
@@ -56,7 +64,36 @@ if (startBtn) {
     };
     devLog('Camera after resize', after);
     startSimulation();
+    running = true;
+    if (pauseBtn) pauseBtn.textContent = 'Pause';
     startBtn.disabled = true;
+  });
+}
+
+if (resetBtn) {
+  resetBtn.addEventListener('click', () => {
+    devLog('Reset button clicked');
+    stopSimulation();
+    setStarted(false);
+    resetRiders();
+    running = false;
+    if (startBtn) startBtn.disabled = false;
+    if (pauseBtn) pauseBtn.textContent = 'Pause';
+  });
+}
+
+if (pauseBtn) {
+  pauseBtn.addEventListener('click', () => {
+    if (!isStarted()) return;
+    if (running) {
+      stopSimulation();
+      running = false;
+      pauseBtn.textContent = 'Resume';
+    } else {
+      startSimulation();
+      running = true;
+      pauseBtn.textContent = 'Pause';
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- add Reset and Pause buttons to control simulation lifecycle
- allow pausing, resuming, and resetting riders via new handlers
- bump version to 1.0.107

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a5b3079f408329b9b773ea1c618963