### PR TITLE
Reset rider physics on start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.105",
+  "version": "1.0.108",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-    "version": "1.0.105",
+      "version": "1.0.108",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.18.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.107",
+  "version": "1.0.108",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/ui/startButton.js
+++ b/src/ui/startButton.js
@@ -30,8 +30,11 @@ function resetRiders() {
     emit('intensityChange', { rider: r, value: r.intensity });
     const pos = r.body.translation();
     r.body.resetForces();
+    // Wake up and synchronise the physics body with its visual mesh
     r.body.setLinvel({ x: 0, y: 0, z: 0 }, true);
-    r.mesh.position.copy(pos);
+    r.body.setTranslation({ x: pos.x, y: pos.y, z: pos.z }, true);
+    r.mesh.position.set(pos.x, pos.y, pos.z);
+    r.speed = 0;
     r.trackDist = polarToDist(pos.x, pos.z);
     r.prevDist = r.trackDist;
     r.lap = 0;


### PR DESCRIPTION
## Summary
- Reset rider physics state when starting the simulation so riders move correctly
- Bump version to 1.0.108

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a5b4d50a0c832996f8366be480c928