### PR TITLE
Enable restart after pausing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.107",
+  "version": "1.0.108",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/ui/startButton.js
+++ b/src/ui/startButton.js
@@ -89,10 +89,12 @@ if (pauseBtn) {
       stopSimulation();
       running = false;
       pauseBtn.textContent = 'Resume';
+      if (startBtn) startBtn.disabled = false;
     } else {
       startSimulation();
       running = true;
       pauseBtn.textContent = 'Pause';
+      if (startBtn) startBtn.disabled = true;
     }
   });
 }


### PR DESCRIPTION
## Summary
- Ensure Start button is re-enabled when simulation is paused
- Disable Start again when resuming
- Bump version to 1.0.108

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a5b4f29fa083298b718b6221e1359e