### PR TITLE
Handle missing raf in simulation start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.108",
+  "version": "1.0.111",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "la_bonne_echappee",
-      "version": "1.0.108",
+      "version": "1.0.111",
       "license": "ISC",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.18.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.110",
+  "version": "1.0.111",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/logic/animation.js
+++ b/src/logic/animation.js
@@ -645,7 +645,17 @@ function loop() {
 }
 
 export function startSimulation() {
-  if (running) return;
+  if (running) {
+    if (rafId === null) {
+      devLog('startSimulation: running but rafId null, restarting');
+      rafId = requestAnimationFrame(loop);
+    }
+    return;
+  }
+  if (rafId !== null) {
+    devLog('startSimulation: rafId not null while not running', { rafId });
+    cancelAnimationFrame(rafId);
+  }
   running = true;
   rafId = requestAnimationFrame(loop);
 }


### PR DESCRIPTION
## Summary
- ensure `startSimulation` handles missing `rafId` and inconsistent states
- bump package version to 1.0.111

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a5bf32f44c8329b351377f41fb8f83