### PR TITLE
Handle Rapier import failures with local fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la_bonne_echappee",
-  "version": "1.0.112",
+  "version": "1.0.113",
   "description": "",
   "main": "src/core/main.js",
   "scripts": {

--- a/src/core/physicsWorld.js
+++ b/src/core/physicsWorld.js
@@ -1,18 +1,30 @@
 // Initialise le monde physique Rapier et gère le pas de simulation
 
-import RAPIER from 'https://cdn.skypack.dev/@dimforge/rapier3d-compat';
+let RAPIER;
+try {
+  ({ default: RAPIER } = await import('https://cdn.skypack.dev/@dimforge/rapier3d-compat'));
+  await RAPIER.init();
+} catch (e) {
+  console.warn('Échec du chargement de Rapier depuis le CDN, tentative locale…', e);
+  try {
+    ({ default: RAPIER } = await import('../../node_modules/@dimforge/rapier3d-compat/rapier.mjs'));
+    await RAPIER.init();
+  } catch (e2) {
+    console.error('Impossible d\'initialiser Rapier', e2);
+    alert('La physique n\'a pas pu être initialisée.');
+  }
+}
 
-// Initialisation de Rapier sans avertissement de paramètres obsolètes
-await RAPIER.init();
-
-const world = new RAPIER.World({ gravity: { x: 0, y: 0, z: 0 } });
+const world = RAPIER ? new RAPIER.World({ gravity: { x: 0, y: 0, z: 0 } }) : null;
 // Augmente le nombre d'itérations du solveur pour mieux gérer les collisions dans un peloton dense
-world.integrationParameters.numSolverIterations = 40;
-world.integrationParameters.numAdditionalFrictionIterations = 40;
+if (world) {
+  world.integrationParameters.numSolverIterations = 40;
+  world.integrationParameters.numAdditionalFrictionIterations = 40;
+}
 
 let physicsAccumulator = 0;
 const fixedTimeStep = 1 / 60;
-world.integrationParameters.dt = fixedTimeStep;
+if (world) world.integrationParameters.dt = fixedTimeStep;
 /**
  * Avance la simulation physique par pas fixes.
  *
@@ -20,6 +32,7 @@ world.integrationParameters.dt = fixedTimeStep;
  * @returns {void}
  */
 function stepPhysics(dt) {
+  if (!world) return;
   physicsAccumulator += dt;
   while (physicsAccumulator >= fixedTimeStep) {
     world.step();


### PR DESCRIPTION
## Summary
- Add try/catch around Rapier import with fallback to bundled module
- Alert user if physics engine fails to initialize
- Increment package version

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a5c15702d883299a7c398379834926